### PR TITLE
ER図のレイアウト改善

### DIFF
--- a/.tbls.yml
+++ b/.tbls.yml
@@ -7,3 +7,7 @@ relations:
     parentTable: images
     parentColumns:
       - id
+
+er:
+  hideDef: true
+  distance: 2


### PR DESCRIPTION
## Summary
- `hideDef: true`: FK定義ラベル（FOREIGN KEY...）を非表示にして文字の重なりを解消
- `distance: 2`: ノード間の距離を広げて見やすく

## Test plan
- [ ] CIでスキーマドキュメントが正常に生成されることを確認
- [ ] ER図の文字が重なっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)