### PR TITLE
OpenAPI仕様とSwagger UIを追加

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,9 @@ jobs:
             ghcr.io/k1low/tbls:v1.92.3 \
             doc "postgres://rikako:password@localhost:5432/rikako?sslmode=disable" /work/docs/schema
 
+      - name: Copy OpenAPI spec
+        run: cp openapi.yaml docs/api/
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rikako API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: "./openapi.yaml",
+      dom_id: '#swagger-ui',
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+      ],
+      layout: "BaseLayout"
+    });
+  </script>
+</body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
 nav:
   - Home: index.md
   - 問題形式仕様書: question-types.md
+  - API: api/index.html
   - DBスキーマ:
       - 概要: schema/README.md
       - questions: schema/public.questions.md

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,275 @@
+openapi: 3.0.3
+info:
+  title: Rikako API
+  description: 問題集アプリのAPI
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8080
+    description: ローカル開発環境
+
+paths:
+  /health:
+    get:
+      summary: ヘルスチェック
+      operationId: healthCheck
+      tags:
+        - System
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /questions:
+    get:
+      summary: 問題一覧取得
+      operationId: getQuestions
+      tags:
+        - Questions
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: 問題一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestionsResponse'
+
+  /questions/{questionId}:
+    get:
+      summary: 問題詳細取得
+      operationId: getQuestion
+      tags:
+        - Questions
+      parameters:
+        - name: questionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: 問題詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Question'
+        '404':
+          description: 問題が見つからない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /workbooks:
+    get:
+      summary: 問題集一覧取得
+      operationId: getWorkbooks
+      tags:
+        - Workbooks
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: 問題集一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkbooksResponse'
+
+  /workbooks/{workbookId}:
+    get:
+      summary: 問題集詳細取得
+      operationId: getWorkbook
+      tags:
+        - Workbooks
+      parameters:
+        - name: workbookId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: 問題集詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkbookDetail'
+        '404':
+          description: 問題集が見つからない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /images/{imageId}:
+    get:
+      summary: 画像取得
+      operationId: getImage
+      tags:
+        - Images
+      parameters:
+        - name: imageId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: 画像
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: 画像が見つからない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          example: ok
+
+    Question:
+      type: object
+      required:
+        - id
+        - type
+        - text
+        - choices
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - single_choice
+        text:
+          type: string
+        choices:
+          type: array
+          items:
+            type: string
+        correct:
+          type: integer
+          description: 正解の選択肢インデックス
+        explanation:
+          type: string
+          description: 解説
+        images:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: 紐付く画像ID
+
+    QuestionsResponse:
+      type: object
+      required:
+        - questions
+        - total
+      properties:
+        questions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Question'
+        total:
+          type: integer
+          description: 総件数
+
+    Workbook:
+      type: object
+      required:
+        - id
+        - title
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        questionCount:
+          type: integer
+          description: 問題数
+
+    WorkbooksResponse:
+      type: object
+      required:
+        - workbooks
+        - total
+      properties:
+        workbooks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Workbook'
+        total:
+          type: integer
+          description: 総件数
+
+    WorkbookDetail:
+      type: object
+      required:
+        - id
+        - title
+        - questions
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        questions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Question'
+
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string


### PR DESCRIPTION
## Summary
- `openapi.yaml`: API仕様を定義（ヘルスチェック、問題、問題集、画像の各エンドポイント）
- `docs/api/index.html`: Swagger UIページ（CDNから読み込み）
- CIでOpenAPI仕様をdocsにコピーしてデプロイ
- MkDocsのナビゲーションにAPIリンクを追加

## エンドポイント
- `GET /health` - ヘルスチェック
- `GET /questions` - 問題一覧
- `GET /questions/{questionId}` - 問題詳細
- `GET /workbooks` - 問題集一覧
- `GET /workbooks/{workbookId}` - 問題集詳細
- `GET /images/{imageId}` - 画像取得

## Test plan
- [ ] CIが正常に実行されることを確認
- [ ] GitHub PagesでSwagger UIが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)