### PR TITLE
CIのキャッシュパスを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('app/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 


### PR DESCRIPTION
## Summary
Go modules キャッシュの警告を修正

## 問題
```
Restore cache failed: Dependencies file is not found in /home/runner/work/rikako/rikako. Supported file pattern: go.sum
```

## 原因
`go.sum` ファイルが `app/` ディレクトリにあるのに、キャッシュキーで `**/go.sum` を使用していたため、正しくファイルが見つからなかった。

## 修正内容
- キャッシュキーのパスを `**/go.sum` から `app/go.sum` に変更

## Test plan
- [ ] CI実行時にキャッシュ警告が出ないこと
- [ ] キャッシュが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)