### PR TITLE
Terraform state lockを有効化する

### DIFF
--- a/terraform/environments/dev/terraform.tf
+++ b/terraform/environments/dev/terraform.tf
@@ -4,6 +4,7 @@ terraform {
     key     = "dev/terraform.tfstate"
     region  = "ap-northeast-1"
     profile = "rikako-shared-sso"
-    encrypt = true
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/terraform/environments/shared/terraform.tf
+++ b/terraform/environments/shared/terraform.tf
@@ -4,6 +4,7 @@ terraform {
     key     = "shared/terraform.tfstate"
     region  = "ap-northeast-1"
     profile = "rikako-shared-sso"
-    encrypt = true
+    encrypt      = true
+    use_lockfile = true
   }
 }


### PR DESCRIPTION
## Summary
- shared / dev 両環境のS3 backendに `use_lockfile = true` を追加
- DynamoDB不要で、S3ネイティブのロック機能を利用

## Test plan
- [ ] `terraform init -reconfigure` で各環境のbackend再初期化を確認
- [ ] `terraform plan` が正常に実行できることを確認

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)