### PR TITLE
APIのID体系をBIGINTに統一

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -3,7 +3,6 @@ module github.com/takoikatakotako/rikako
 go 1.24.0
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.15.0
 	github.com/lib/pq v1.10.9
 	github.com/oapi-codegen/runtime v1.2.0
@@ -12,6 +11,7 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -18,8 +18,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
-github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oapi-codegen/runtime v1.2.0 h1:RvKc1CVS1QeKSNzO97FBQbSMZyQ8s6rZd+LpmzwHMP4=
 github.com/oapi-codegen/runtime v1.2.0/go.mod h1:Y7ZhmmlE8ikZOmuHRRndiIm7nf3xcVv+YMweKgG1DT0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/app/internal/api/api.gen.go
+++ b/app/internal/api/api.gen.go
@@ -12,7 +12,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/oapi-codegen/runtime"
 	strictecho "github.com/oapi-codegen/runtime/strictmiddleware/echo"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 // Defines values for QuestionType.
@@ -53,8 +52,8 @@ type Question struct {
 	Correct *int `json:"correct,omitempty"`
 
 	// Explanation 解説
-	Explanation *string            `json:"explanation,omitempty"`
-	Id          openapi_types.UUID `json:"id"`
+	Explanation *string `json:"explanation,omitempty"`
+	Id          int64   `json:"id"`
 
 	// Images 画像URL
 	Images *[]string    `json:"images,omitempty"`
@@ -75,8 +74,8 @@ type QuestionsResponse struct {
 
 // Workbook defines model for Workbook.
 type Workbook struct {
-	Description *string            `json:"description,omitempty"`
-	Id          openapi_types.UUID `json:"id"`
+	Description *string `json:"description,omitempty"`
+	Id          int64   `json:"id"`
 
 	// QuestionCount 問題数
 	QuestionCount *int   `json:"questionCount,omitempty"`
@@ -85,10 +84,10 @@ type Workbook struct {
 
 // WorkbookDetail defines model for WorkbookDetail.
 type WorkbookDetail struct {
-	Description *string            `json:"description,omitempty"`
-	Id          openapi_types.UUID `json:"id"`
-	Questions   []Question         `json:"questions"`
-	Title       string             `json:"title"`
+	Description *string    `json:"description,omitempty"`
+	Id          int64      `json:"id"`
+	Questions   []Question `json:"questions"`
+	Title       string     `json:"title"`
 }
 
 // WorkbooksResponse defines model for WorkbooksResponse.
@@ -123,13 +122,13 @@ type ServerInterface interface {
 	GetQuestions(ctx echo.Context, params GetQuestionsParams) error
 	// 問題詳細取得
 	// (GET /questions/{questionId})
-	GetQuestion(ctx echo.Context, questionId openapi_types.UUID) error
+	GetQuestion(ctx echo.Context, questionId int64) error
 	// 問題集一覧取得
 	// (GET /workbooks)
 	GetWorkbooks(ctx echo.Context, params GetWorkbooksParams) error
 	// 問題集詳細取得
 	// (GET /workbooks/{workbookId})
-	GetWorkbook(ctx echo.Context, workbookId openapi_types.UUID) error
+	GetWorkbook(ctx echo.Context, workbookId int64) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -184,9 +183,9 @@ func (w *ServerInterfaceWrapper) GetQuestions(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetQuestion(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "questionId" -------------
-	var questionId openapi_types.UUID
+	var questionId int64
 
-	err = runtime.BindStyledParameterWithOptions("simple", "questionId", ctx.Param("questionId"), &questionId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	err = runtime.BindStyledParameterWithOptions("simple", "questionId", ctx.Param("questionId"), &questionId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter questionId: %s", err))
 	}
@@ -225,9 +224,9 @@ func (w *ServerInterfaceWrapper) GetWorkbooks(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetWorkbook(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "workbookId" -------------
-	var workbookId openapi_types.UUID
+	var workbookId int64
 
-	err = runtime.BindStyledParameterWithOptions("simple", "workbookId", ctx.Param("workbookId"), &workbookId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	err = runtime.BindStyledParameterWithOptions("simple", "workbookId", ctx.Param("workbookId"), &workbookId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workbookId: %s", err))
 	}
@@ -324,7 +323,7 @@ func (response GetQuestions200JSONResponse) VisitGetQuestionsResponse(w http.Res
 }
 
 type GetQuestionRequestObject struct {
-	QuestionId openapi_types.UUID `json:"questionId"`
+	QuestionId int64 `json:"questionId"`
 }
 
 type GetQuestionResponseObject interface {
@@ -367,7 +366,7 @@ func (response GetWorkbooks200JSONResponse) VisitGetWorkbooksResponse(w http.Res
 }
 
 type GetWorkbookRequestObject struct {
-	WorkbookId openapi_types.UUID `json:"workbookId"`
+	WorkbookId int64 `json:"workbookId"`
 }
 
 type GetWorkbookResponseObject interface {
@@ -498,7 +497,7 @@ func (sh *strictHandler) GetQuestions(ctx echo.Context, params GetQuestionsParam
 }
 
 // GetQuestion operation middleware
-func (sh *strictHandler) GetQuestion(ctx echo.Context, questionId openapi_types.UUID) error {
+func (sh *strictHandler) GetQuestion(ctx echo.Context, questionId int64) error {
 	var request GetQuestionRequestObject
 
 	request.QuestionId = questionId
@@ -548,7 +547,7 @@ func (sh *strictHandler) GetWorkbooks(ctx echo.Context, params GetWorkbooksParam
 }
 
 // GetWorkbook operation middleware
-func (sh *strictHandler) GetWorkbook(ctx echo.Context, workbookId openapi_types.UUID) error {
+func (sh *strictHandler) GetWorkbook(ctx echo.Context, workbookId int64) error {
 	var request GetWorkbookRequestObject
 
 	request.WorkbookId = workbookId

--- a/app/internal/handler/handler.go
+++ b/app/internal/handler/handler.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/takoikatakotako/rikako/internal/api"
 )
 
@@ -127,8 +126,8 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 		choiceRows.Close()
 
 		q := api.Question{
-			Id:      uuid.MustParse(uuidFromInt(id)),
-			Type:    api.SingleChoice,
+			Id:   id,
+			Type: api.SingleChoice,
 			Text:    text,
 			Choices: choices,
 			Correct: &correct,
@@ -200,8 +199,8 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 	}
 
 	q := api.Question{
-		Id:      request.QuestionId,
-		Type:    api.SingleChoice,
+		Id:   id,
+		Type: api.SingleChoice,
 		Text:    text,
 		Choices: choices,
 		Correct: &correct,
@@ -263,7 +262,7 @@ func (h *Handler) GetWorkbooks(ctx context.Context, request api.GetWorkbooksRequ
 		}
 
 		w := api.Workbook{
-			Id:            uuid.MustParse(uuidFromInt(id)),
+			Id:            id,
 			Title:         title,
 			QuestionCount: &questionCount,
 		}
@@ -348,7 +347,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 		choiceRows.Close()
 
 		q := api.Question{
-			Id:      uuid.MustParse(uuidFromInt(qid)),
+			Id:   qid,
 			Type:    api.SingleChoice,
 			Text:    text,
 			Choices: choices,
@@ -370,7 +369,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 	}
 
 	w := api.WorkbookDetail{
-		Id:        request.WorkbookId,
+		Id:        id,
 		Title:     title,
 		Questions: questions,
 	}
@@ -379,10 +378,4 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 	}
 
 	return api.GetWorkbook200JSONResponse(w), nil
-}
-
-// TODO: DBのIDがBIGINTなので、UUIDとの変換が必要
-// 本来はDBにUUIDを格納するか、別途マッピングテーブルを用意すべき
-func uuidFromInt(id int64) string {
-	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(string(rune(id)))).String()
 }

--- a/app/internal/handler/handler_test.go
+++ b/app/internal/handler/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	_ "github.com/lib/pq"
 	"github.com/takoikatakotako/rikako/internal/api"
 )
@@ -90,8 +89,8 @@ func TestGetQuestions(t *testing.T) {
 		}
 
 		q := res.Questions[0]
-		if q.Id == uuid.Nil {
-			t.Error("expected question ID to be non-nil")
+		if q.Id == 0 {
+			t.Error("expected question ID to be non-zero")
 		}
 		if q.Text == "" {
 			t.Error("expected question text to be non-empty")
@@ -124,8 +123,52 @@ func TestGetQuestions(t *testing.T) {
 	})
 }
 
-// TODO: GetQuestion / GetWorkbook の個別取得テストは #22 (UUID移行) 後に追加
-// 現在はDBがBIGINT IDだがAPIはUUIDを受け取るためテスト不可
+func TestGetQuestion(t *testing.T) {
+	h := New(testDB, "https://cdn.example.com")
+
+	t.Run("existing question", func(t *testing.T) {
+		var dbID int64
+		err := testDB.QueryRow("SELECT id FROM questions ORDER BY id LIMIT 1").Scan(&dbID)
+		if err != nil {
+			t.Skip("no questions in DB")
+		}
+
+		resp, err := h.GetQuestion(context.Background(), api.GetQuestionRequestObject{
+			QuestionId: dbID,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		res, ok := resp.(api.GetQuestion200JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetQuestion200JSONResponse, got %T", resp)
+		}
+		if res.Id != dbID {
+			t.Errorf("expected ID %d, got %d", dbID, res.Id)
+		}
+		if res.Text == "" {
+			t.Error("expected text to be non-empty")
+		}
+		if len(res.Choices) == 0 {
+			t.Error("expected choices to be non-empty")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		resp, err := h.GetQuestion(context.Background(), api.GetQuestionRequestObject{
+			QuestionId: 999999999,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		_, ok := resp.(api.GetQuestion404JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetQuestion404JSONResponse, got %T", resp)
+		}
+	})
+}
 
 func TestGetWorkbooks(t *testing.T) {
 	h := New(testDB, "https://cdn.example.com")
@@ -156,6 +199,49 @@ func TestGetWorkbooks(t *testing.T) {
 	}
 }
 
+func TestGetWorkbook(t *testing.T) {
+	h := New(testDB, "https://cdn.example.com")
+
+	t.Run("existing workbook", func(t *testing.T) {
+		var dbID int64
+		err := testDB.QueryRow("SELECT id FROM workbooks ORDER BY id LIMIT 1").Scan(&dbID)
+		if err != nil {
+			t.Skip("no workbooks in DB")
+		}
+
+		resp, err := h.GetWorkbook(context.Background(), api.GetWorkbookRequestObject{
+			WorkbookId: dbID,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		res, ok := resp.(api.GetWorkbook200JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetWorkbook200JSONResponse, got %T", resp)
+		}
+		if res.Title == "" {
+			t.Error("expected title to be non-empty")
+		}
+		if len(res.Questions) == 0 {
+			t.Error("expected questions to be non-empty")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		resp, err := h.GetWorkbook(context.Background(), api.GetWorkbookRequestObject{
+			WorkbookId: 999999999,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		_, ok := resp.(api.GetWorkbook404JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetWorkbook404JSONResponse, got %T", resp)
+		}
+	})
+}
 
 func TestGetQuestionsWithImages(t *testing.T) {
 	h := New(testDB, "https://cdn.example.com")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -74,8 +74,8 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            format: uuid
+            type: integer
+            format: int64
       responses:
         '200':
           description: 問題詳細
@@ -127,8 +127,8 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            format: uuid
+            type: integer
+            format: int64
       responses:
         '200':
           description: 問題集詳細
@@ -173,8 +173,8 @@ components:
         - choices
       properties:
         id:
-          type: string
-          format: uuid
+          type: integer
+          format: int64
         type:
           type: string
           enum:
@@ -219,8 +219,8 @@ components:
         - title
       properties:
         id:
-          type: string
-          format: uuid
+          type: integer
+          format: int64
         title:
           type: string
         description:
@@ -251,8 +251,8 @@ components:
         - questions
       properties:
         id:
-          type: string
-          format: uuid
+          type: integer
+          format: int64
         title:
           type: string
         description:


### PR DESCRIPTION
## Summary
- OpenAPIのid/questionId/workbookIdを`uuid`から`int64`に変更
- ハンドラーから`uuidFromInt`変換ロジックと`google/uuid`依存を削除
- GetQuestion/GetWorkbookの個別取得テストを追加（UUID不整合が解消されテスト可能に）

## Test plan
- [x] ローカルで全テストPASS確認済み（GetQuestion/GetWorkbook含む）
- [ ] CIでテストが通ることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)