### PR TITLE
エラーレスポンス統一・バリデーション強化・構造化ログ導入

### DIFF
--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"database/sql"
-	"log"
+	"errors"
+	"log/slog"
+	"net/http"
 	"os"
 	"time"
 
@@ -12,9 +14,12 @@ import (
 	"github.com/takoikatakotako/rikako/internal/api"
 	"github.com/takoikatakotako/rikako/internal/auth"
 	"github.com/takoikatakotako/rikako/internal/handler"
+	"github.com/takoikatakotako/rikako/internal/logging"
 )
 
 func main() {
+	logger := logging.NewLogger()
+
 	// DB接続
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
@@ -23,12 +28,14 @@ func main() {
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
-		log.Fatalf("failed to connect to database: %v", err)
+		logger.Error("failed to connect to database", "error", err)
+		os.Exit(1)
 	}
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatalf("failed to ping database: %v", err)
+		logger.Error("failed to ping database", "error", err)
+		os.Exit(1)
 	}
 
 	// DB接続プーリング設定（Lambda最適化）
@@ -45,9 +52,12 @@ func main() {
 
 	// Echo初期化
 	e := echo.New()
-	e.Use(middleware.Logger())
+	e.Use(logging.RequestLogger(logger))
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORS())
+
+	// カスタムエラーハンドラ
+	e.HTTPErrorHandler = newHTTPErrorHandler(logger)
 
 	// 認証ミドルウェア
 	cognitoRegion := os.Getenv("COGNITO_REGION")
@@ -59,7 +69,7 @@ func main() {
 	}
 
 	// ハンドラー登録
-	h := handler.New(db, imageBaseURL)
+	h := handler.New(db, imageBaseURL, logger)
 	strictHandler := api.NewStrictHandler(h, middlewares)
 	api.RegisterHandlers(e, strictHandler)
 
@@ -69,8 +79,43 @@ func main() {
 		port = "8080"
 	}
 
-	log.Printf("Starting server on :%s", port)
+	logger.Info("starting server", "port", port)
 	if err := e.Start(":" + port); err != nil {
-		log.Fatalf("failed to start server: %v", err)
+		logger.Error("failed to start server", "error", err)
+		os.Exit(1)
+	}
+}
+
+func newHTTPErrorHandler(logger *slog.Logger) func(err error, c echo.Context) {
+	return func(err error, c echo.Context) {
+		if c.Response().Committed {
+			return
+		}
+
+		code := http.StatusInternalServerError
+		errCode := "INTERNAL_ERROR"
+		msg := "internal server error"
+
+		var he *echo.HTTPError
+		if errors.As(err, &he) {
+			code = he.Code
+			if m, ok := he.Message.(string); ok {
+				msg = m
+			}
+			switch code {
+			case http.StatusBadRequest:
+				errCode = "INVALID_PARAMETER"
+			case http.StatusUnauthorized:
+				errCode = "UNAUTHORIZED"
+			case http.StatusNotFound:
+				errCode = "NOT_FOUND"
+			}
+		}
+
+		if code >= 500 {
+			logger.Error("unhandled error", "error", err, "status", code)
+		}
+
+		c.JSON(code, api.Error{Code: errCode, Message: msg})
 	}
 }

--- a/app/internal/api/api.gen.go
+++ b/app/internal/api/api.gen.go
@@ -35,6 +35,10 @@ func (e QuestionType) Valid() bool {
 
 // Error defines model for Error.
 type Error struct {
+	// Code 機械可読なエラーコード
+	Code string `json:"code"`
+
+	// Message 人間可読なエラーメッセージ
 	Message string `json:"message"`
 }
 
@@ -334,6 +338,15 @@ func (response GetQuestions200JSONResponse) VisitGetQuestionsResponse(w http.Res
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetQuestions400JSONResponse Error
+
+func (response GetQuestions400JSONResponse) VisitGetQuestionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetQuestions401JSONResponse Error
 
 func (response GetQuestions401JSONResponse) VisitGetQuestionsResponse(w http.ResponseWriter) error {
@@ -391,6 +404,15 @@ type GetWorkbooks200JSONResponse WorkbooksResponse
 func (response GetWorkbooks200JSONResponse) VisitGetWorkbooksResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWorkbooks400JSONResponse Error
+
+func (response GetWorkbooks400JSONResponse) VisitGetWorkbooksResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/app/internal/handler/handler.go
+++ b/app/internal/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 
 	"github.com/takoikatakotako/rikako/internal/api"
 )
@@ -11,13 +12,32 @@ import (
 type Handler struct {
 	db           *sql.DB
 	imageBaseURL string
+	logger       *slog.Logger
 }
 
-func New(db *sql.DB, imageBaseURL string) *Handler {
+func New(db *sql.DB, imageBaseURL string, logger *slog.Logger) *Handler {
 	return &Handler{
 		db:           db,
 		imageBaseURL: imageBaseURL,
+		logger:       logger,
 	}
+}
+
+func validatePagination(limit, offset *int) (int, int, error) {
+	l, o := 20, 0
+	if limit != nil {
+		l = *limit
+	}
+	if offset != nil {
+		o = *offset
+	}
+	if l < 1 || l > 100 {
+		return 0, 0, fmt.Errorf("limit must be between 1 and 100")
+	}
+	if o < 0 {
+		return 0, 0, fmt.Errorf("offset must be >= 0")
+	}
+	return l, o, nil
 }
 
 func (h *Handler) Root(ctx context.Context, request api.RootRequestObject) (api.RootResponseObject, error) {
@@ -58,19 +78,16 @@ func (h *Handler) getImageURLs(ctx context.Context, questionID int64) ([]string,
 }
 
 func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequestObject) (api.GetQuestionsResponseObject, error) {
-	limit := 20
-	offset := 0
-	if request.Params.Limit != nil {
-		limit = *request.Params.Limit
-	}
-	if request.Params.Offset != nil {
-		offset = *request.Params.Offset
+	limit, offset, err := validatePagination(request.Params.Limit, request.Params.Offset)
+	if err != nil {
+		return api.GetQuestions400JSONResponse{Code: "INVALID_PARAMETER", Message: err.Error()}, nil
 	}
 
 	// 総件数取得
 	var total int
-	err := h.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM questions").Scan(&total)
+	err = h.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM questions").Scan(&total)
 	if err != nil {
+		h.logger.Error("failed to count questions", "error", err)
 		return nil, err
 	}
 
@@ -83,6 +100,7 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 		LIMIT $1 OFFSET $2
 	`, limit, offset)
 	if err != nil {
+		h.logger.Error("failed to query questions", "error", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -94,6 +112,7 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 		var explanation sql.NullString
 
 		if err := rows.Scan(&id, &text, &explanation); err != nil {
+			h.logger.Error("failed to scan question", "error", err)
 			return nil, err
 		}
 
@@ -105,6 +124,7 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 			ORDER BY choice_index
 		`, id)
 		if err != nil {
+			h.logger.Error("failed to query choices", "error", err, "question_id", id)
 			return nil, err
 		}
 
@@ -116,6 +136,7 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 			var choiceIndex int
 			if err := choiceRows.Scan(&choiceText, &isCorrect, &choiceIndex); err != nil {
 				choiceRows.Close()
+				h.logger.Error("failed to scan choice", "error", err)
 				return nil, err
 			}
 			choices = append(choices, choiceText)
@@ -126,8 +147,8 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 		choiceRows.Close()
 
 		q := api.Question{
-			Id:   id,
-			Type: api.SingleChoice,
+			Id:      id,
+			Type:    api.SingleChoice,
 			Text:    text,
 			Choices: choices,
 			Correct: &correct,
@@ -138,6 +159,7 @@ func (h *Handler) GetQuestions(ctx context.Context, request api.GetQuestionsRequ
 
 		imageURLs, err := h.getImageURLs(ctx, id)
 		if err != nil {
+			h.logger.Error("failed to get image URLs", "error", err, "question_id", id)
 			return nil, err
 		}
 		if len(imageURLs) > 0 {
@@ -165,9 +187,10 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 		WHERE q.id = $1
 	`, request.QuestionId).Scan(&id, &text, &explanation)
 	if err == sql.ErrNoRows {
-		return api.GetQuestion404JSONResponse{Message: "question not found"}, nil
+		return api.GetQuestion404JSONResponse{Code: "NOT_FOUND", Message: "question not found"}, nil
 	}
 	if err != nil {
+		h.logger.Error("failed to query question", "error", err, "question_id", request.QuestionId)
 		return nil, err
 	}
 
@@ -179,6 +202,7 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 		ORDER BY choice_index
 	`, id)
 	if err != nil {
+		h.logger.Error("failed to query choices", "error", err, "question_id", id)
 		return nil, err
 	}
 	defer choiceRows.Close()
@@ -190,6 +214,7 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 		var isCorrect bool
 		var choiceIndex int
 		if err := choiceRows.Scan(&choiceText, &isCorrect, &choiceIndex); err != nil {
+			h.logger.Error("failed to scan choice", "error", err)
 			return nil, err
 		}
 		choices = append(choices, choiceText)
@@ -199,8 +224,8 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 	}
 
 	q := api.Question{
-		Id:   id,
-		Type: api.SingleChoice,
+		Id:      id,
+		Type:    api.SingleChoice,
 		Text:    text,
 		Choices: choices,
 		Correct: &correct,
@@ -211,6 +236,7 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 
 	imageURLs, err := h.getImageURLs(ctx, id)
 	if err != nil {
+		h.logger.Error("failed to get image URLs", "error", err, "question_id", id)
 		return nil, err
 	}
 	if len(imageURLs) > 0 {
@@ -221,19 +247,16 @@ func (h *Handler) GetQuestion(ctx context.Context, request api.GetQuestionReques
 }
 
 func (h *Handler) GetWorkbooks(ctx context.Context, request api.GetWorkbooksRequestObject) (api.GetWorkbooksResponseObject, error) {
-	limit := 20
-	offset := 0
-	if request.Params.Limit != nil {
-		limit = *request.Params.Limit
-	}
-	if request.Params.Offset != nil {
-		offset = *request.Params.Offset
+	limit, offset, err := validatePagination(request.Params.Limit, request.Params.Offset)
+	if err != nil {
+		return api.GetWorkbooks400JSONResponse{Code: "INVALID_PARAMETER", Message: err.Error()}, nil
 	}
 
 	// 総件数取得
 	var total int
-	err := h.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM workbooks").Scan(&total)
+	err = h.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM workbooks").Scan(&total)
 	if err != nil {
+		h.logger.Error("failed to count workbooks", "error", err)
 		return nil, err
 	}
 
@@ -246,6 +269,7 @@ func (h *Handler) GetWorkbooks(ctx context.Context, request api.GetWorkbooksRequ
 		LIMIT $1 OFFSET $2
 	`, limit, offset)
 	if err != nil {
+		h.logger.Error("failed to query workbooks", "error", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -258,6 +282,7 @@ func (h *Handler) GetWorkbooks(ctx context.Context, request api.GetWorkbooksRequ
 		var questionCount int
 
 		if err := rows.Scan(&id, &title, &description, &questionCount); err != nil {
+			h.logger.Error("failed to scan workbook", "error", err)
 			return nil, err
 		}
 
@@ -288,9 +313,10 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 		SELECT id, title, description FROM workbooks WHERE id = $1
 	`, request.WorkbookId).Scan(&id, &title, &description)
 	if err == sql.ErrNoRows {
-		return api.GetWorkbook404JSONResponse{Message: "workbook not found"}, nil
+		return api.GetWorkbook404JSONResponse{Code: "NOT_FOUND", Message: "workbook not found"}, nil
 	}
 	if err != nil {
+		h.logger.Error("failed to query workbook", "error", err, "workbook_id", request.WorkbookId)
 		return nil, err
 	}
 
@@ -304,6 +330,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 		ORDER BY wq.order_index
 	`, id)
 	if err != nil {
+		h.logger.Error("failed to query workbook questions", "error", err, "workbook_id", id)
 		return nil, err
 	}
 	defer rows.Close()
@@ -315,6 +342,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 		var explanation sql.NullString
 
 		if err := rows.Scan(&qid, &text, &explanation); err != nil {
+			h.logger.Error("failed to scan question", "error", err)
 			return nil, err
 		}
 
@@ -326,6 +354,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 			ORDER BY choice_index
 		`, qid)
 		if err != nil {
+			h.logger.Error("failed to query choices", "error", err, "question_id", qid)
 			return nil, err
 		}
 
@@ -337,6 +366,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 			var choiceIndex int
 			if err := choiceRows.Scan(&choiceText, &isCorrect, &choiceIndex); err != nil {
 				choiceRows.Close()
+				h.logger.Error("failed to scan choice", "error", err)
 				return nil, err
 			}
 			choices = append(choices, choiceText)
@@ -347,7 +377,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 		choiceRows.Close()
 
 		q := api.Question{
-			Id:   qid,
+			Id:      qid,
 			Type:    api.SingleChoice,
 			Text:    text,
 			Choices: choices,
@@ -359,6 +389,7 @@ func (h *Handler) GetWorkbook(ctx context.Context, request api.GetWorkbookReques
 
 		imageURLs, err := h.getImageURLs(ctx, qid)
 		if err != nil {
+			h.logger.Error("failed to get image URLs", "error", err, "question_id", qid)
 			return nil, err
 		}
 		if len(imageURLs) > 0 {

--- a/app/internal/handler/handler_test.go
+++ b/app/internal/handler/handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 )
 
 var testDB *sql.DB
+var testLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 func TestMain(m *testing.M) {
 	dsn := os.Getenv("DATABASE_URL")
@@ -33,7 +35,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRoot(t *testing.T) {
-	h := New(testDB, "https://example.com")
+	h := New(testDB, "https://example.com", testLogger)
 	resp, err := h.Root(context.Background(), api.RootRequestObject{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -49,7 +51,7 @@ func TestRoot(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	h := New(testDB, "https://example.com")
+	h := New(testDB, "https://example.com", testLogger)
 	resp, err := h.HealthCheck(context.Background(), api.HealthCheckRequestObject{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -65,7 +67,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestGetQuestions(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com")
+	h := New(testDB, "https://cdn.example.com", testLogger)
 
 	t.Run("default pagination", func(t *testing.T) {
 		resp, err := h.GetQuestions(context.Background(), api.GetQuestionsRequestObject{})
@@ -121,10 +123,55 @@ func TestGetQuestions(t *testing.T) {
 			t.Errorf("expected 5 questions, got %d", len(res.Questions))
 		}
 	})
+
+	t.Run("invalid limit zero", func(t *testing.T) {
+		limit := 0
+		resp, err := h.GetQuestions(context.Background(), api.GetQuestionsRequestObject{
+			Params: api.GetQuestionsParams{Limit: &limit},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		res, ok := resp.(api.GetQuestions400JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetQuestions400JSONResponse, got %T", resp)
+		}
+		if res.Code != "INVALID_PARAMETER" {
+			t.Errorf("expected code 'INVALID_PARAMETER', got '%s'", res.Code)
+		}
+	})
+
+	t.Run("invalid limit over 100", func(t *testing.T) {
+		limit := 101
+		resp, err := h.GetQuestions(context.Background(), api.GetQuestionsRequestObject{
+			Params: api.GetQuestionsParams{Limit: &limit},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, ok := resp.(api.GetQuestions400JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetQuestions400JSONResponse, got %T", resp)
+		}
+	})
+
+	t.Run("invalid negative offset", func(t *testing.T) {
+		offset := -1
+		resp, err := h.GetQuestions(context.Background(), api.GetQuestionsRequestObject{
+			Params: api.GetQuestionsParams{Offset: &offset},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, ok := resp.(api.GetQuestions400JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetQuestions400JSONResponse, got %T", resp)
+		}
+	})
 }
 
 func TestGetQuestion(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com")
+	h := New(testDB, "https://cdn.example.com", testLogger)
 
 	t.Run("existing question", func(t *testing.T) {
 		var dbID int64
@@ -163,44 +210,63 @@ func TestGetQuestion(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		_, ok := resp.(api.GetQuestion404JSONResponse)
+		res, ok := resp.(api.GetQuestion404JSONResponse)
 		if !ok {
 			t.Fatalf("expected GetQuestion404JSONResponse, got %T", resp)
+		}
+		if res.Code != "NOT_FOUND" {
+			t.Errorf("expected code 'NOT_FOUND', got '%s'", res.Code)
 		}
 	})
 }
 
 func TestGetWorkbooks(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com")
+	h := New(testDB, "https://cdn.example.com", testLogger)
 
-	resp, err := h.GetWorkbooks(context.Background(), api.GetWorkbooksRequestObject{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	t.Run("default", func(t *testing.T) {
+		resp, err := h.GetWorkbooks(context.Background(), api.GetWorkbooksRequestObject{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
-	res, ok := resp.(api.GetWorkbooks200JSONResponse)
-	if !ok {
-		t.Fatalf("expected GetWorkbooks200JSONResponse, got %T", resp)
-	}
+		res, ok := resp.(api.GetWorkbooks200JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetWorkbooks200JSONResponse, got %T", resp)
+		}
 
-	if res.Total == 0 {
-		t.Fatal("expected total > 0")
-	}
-	if len(res.Workbooks) == 0 {
-		t.Fatal("expected workbooks to be non-empty")
-	}
+		if res.Total == 0 {
+			t.Fatal("expected total > 0")
+		}
+		if len(res.Workbooks) == 0 {
+			t.Fatal("expected workbooks to be non-empty")
+		}
 
-	w := res.Workbooks[0]
-	if w.Title == "" {
-		t.Error("expected workbook title to be non-empty")
-	}
-	if w.QuestionCount == nil || *w.QuestionCount == 0 {
-		t.Error("expected question count > 0")
-	}
+		w := res.Workbooks[0]
+		if w.Title == "" {
+			t.Error("expected workbook title to be non-empty")
+		}
+		if w.QuestionCount == nil || *w.QuestionCount == 0 {
+			t.Error("expected question count > 0")
+		}
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		limit := -5
+		resp, err := h.GetWorkbooks(context.Background(), api.GetWorkbooksRequestObject{
+			Params: api.GetWorkbooksParams{Limit: &limit},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, ok := resp.(api.GetWorkbooks400JSONResponse)
+		if !ok {
+			t.Fatalf("expected GetWorkbooks400JSONResponse, got %T", resp)
+		}
+	})
 }
 
 func TestGetWorkbook(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com")
+	h := New(testDB, "https://cdn.example.com", testLogger)
 
 	t.Run("existing workbook", func(t *testing.T) {
 		var dbID int64
@@ -236,15 +302,18 @@ func TestGetWorkbook(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		_, ok := resp.(api.GetWorkbook404JSONResponse)
+		res, ok := resp.(api.GetWorkbook404JSONResponse)
 		if !ok {
 			t.Fatalf("expected GetWorkbook404JSONResponse, got %T", resp)
+		}
+		if res.Code != "NOT_FOUND" {
+			t.Errorf("expected code 'NOT_FOUND', got '%s'", res.Code)
 		}
 	})
 }
 
 func TestGetQuestionsWithImages(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com")
+	h := New(testDB, "https://cdn.example.com", testLogger)
 
 	// Fetch enough questions to find some with images
 	limit := 100

--- a/app/internal/logging/logger.go
+++ b/app/internal/logging/logger.go
@@ -1,0 +1,23 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// NewLogger creates a JSON slog.Logger with level configured via LOG_LEVEL env var.
+func NewLogger() *slog.Logger {
+	level := slog.LevelInfo
+	if l := os.Getenv("LOG_LEVEL"); l != "" {
+		switch strings.ToUpper(l) {
+		case "DEBUG":
+			level = slog.LevelDebug
+		case "WARN":
+			level = slog.LevelWarn
+		case "ERROR":
+			level = slog.LevelError
+		}
+	}
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+}

--- a/app/internal/logging/middleware.go
+++ b/app/internal/logging/middleware.go
@@ -1,0 +1,48 @@
+package logging
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// RequestLogger returns an Echo middleware that logs requests using slog in JSON format.
+func RequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			start := time.Now()
+
+			err := next(c)
+			if err != nil {
+				c.Error(err)
+			}
+
+			latency := time.Since(start)
+			req := c.Request()
+			status := c.Response().Status
+
+			attrs := []slog.Attr{
+				slog.String("method", req.Method),
+				slog.String("path", req.URL.Path),
+				slog.Int("status", status),
+				slog.String("latency", latency.String()),
+				slog.String("remote_ip", c.RealIP()),
+			}
+
+			if query := req.URL.RawQuery; query != "" {
+				attrs = append(attrs, slog.String("query", query))
+			}
+
+			if status >= 500 {
+				logger.LogAttrs(req.Context(), slog.LevelError, "request", attrs...)
+			} else if status >= 400 {
+				logger.LogAttrs(req.Context(), slog.LevelWarn, "request", attrs...)
+			} else {
+				logger.LogAttrs(req.Context(), slog.LevelInfo, "request", attrs...)
+			}
+
+			return nil
+		}
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,12 +54,14 @@ paths:
           schema:
             type: integer
             default: 20
+            minimum: 1
             maximum: 100
         - name: offset
           in: query
           schema:
             type: integer
             default: 0
+            minimum: 0
       responses:
         '200':
           description: 問題一覧
@@ -67,6 +69,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/QuestionsResponse'
+        '400':
+          description: パラメータ不正
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: 認証エラー
           content:
@@ -119,12 +127,14 @@ paths:
           schema:
             type: integer
             default: 20
+            minimum: 1
             maximum: 100
         - name: offset
           in: query
           schema:
             type: integer
             default: 0
+            minimum: 0
       responses:
         '200':
           description: 問題集一覧
@@ -132,6 +142,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkbooksResponse'
+        '400':
+          description: パラメータ不正
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: 認証エラー
           content:
@@ -299,7 +315,13 @@ components:
     Error:
       type: object
       required:
+        - code
         - message
       properties:
+        code:
+          type: string
+          description: 機械可読なエラーコード
+          example: INVALID_PARAMETER
         message:
           type: string
+          description: 人間可読なエラーメッセージ


### PR DESCRIPTION
## Summary
- Error スキーマに `code` フィールドを追加し、全エラーレスポンスを `{code, message}` 形式に統一
- `limit`/`offset` パラメータのバリデーション（1-100, >= 0）を追加、不正値で 400 を返却
- カスタム `HTTPErrorHandler` で 500/401 等の未ハンドルエラーも統一フォーマットで返却
- `log/slog` による JSON 構造化ログを導入（CloudWatch Logs 対応）
- Echo のリクエストログを slog ベースミドルウェアに置き換え（method, path, status, latency, remote_ip）
- `LOG_LEVEL` 環境変数でログレベル切り替え（DEBUG/INFO/WARN/ERROR）

Closes #49, Closes #28

## Test plan
- [x] `go build ./cmd/server` — ビルド成功
- [x] `go test ./...` — 全テスト通過
- [x] バリデーションテスト追加（limit=0, limit=101, offset=-1 で 400）
- [x] 404 レスポンスの `code` フィールド検証テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)