### PR TITLE
migrate.ymlのAWS認証をOIDCに移行

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform


### PR DESCRIPTION
## Summary
- migrate.ymlのAWS認証をアクセスキー方式からOIDC（IAMロール）方式に変更
- deploy-dev.ymlと認証方式を統一

## Test plan
- [ ] GitHub Actionsの手動実行（workflow_dispatch）でdev環境のマイグレーションが動作すること
- [ ] 不要になったAWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEYシークレットを削除

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)