### PR TITLE
ECRイメージスキャン有効化と保持数を5に変更

### DIFF
--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -3,8 +3,8 @@ module "ecr_api" {
 
   repository_name      = "rikako-api"
   image_tag_mutability = "MUTABLE"
-  scan_on_push         = false
-  max_image_count      = 20
+  scan_on_push         = true
+  max_image_count      = 5
   allowed_account_ids  = local.allowed_account_ids
 
   tags = {


### PR DESCRIPTION
## Summary
- ECR Basic scanning を有効化（プッシュ時にCVEスキャン、無料）
- イメージ保持数を20→5に変更（古いイメージを自動削除）

## Test plan
- [ ] `terraform plan` で差分確認（shared環境）
- [ ] `terraform apply` 後、ECRコンソールでスキャン設定とライフサイクルポリシーを確認

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)