### PR TITLE
docsナビにiOSアプリページを追加

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Home: index.md
   - アーキテクチャ: architecture.md
   - 問題形式仕様書: question-types.md
+  - iOSアプリ: ios.md
   - API: api/index.html
   - DBスキーマ:
       - 概要: schema/README.md


### PR DESCRIPTION
## Summary
- mkdocs.ymlのnavにiOSアプリページ（ios.md）を追加
- GitHub Pagesで画面遷移図（Mermaid）が閲覧可能になる

## Test plan
- [ ] デプロイ後 https://takoikatakotako.github.io/rikako/ios/ でMermaid図が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)