### PR TITLE
スクリーンショットArtifact対応とworkflow_dispatch追加

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -127,11 +127,27 @@ jobs:
                   print(f"Extracted: {name}.png")
           PYTHON
 
+      - name: Generate screenshot board
+        working-directory: ./ios
+        run: |
+          brew install imagemagick
+          montage \
+            -label '問題集一覧' screenshots/01_workbook_list.png \
+            -label '問題集詳細' screenshots/02_workbook_detail.png \
+            -label 'クイズ(解答前)' screenshots/03_quiz_before_answer.png \
+            -label 'クイズ(解答後)' screenshots/04_quiz_after_answer.png \
+            -label '結果' screenshots/05_result.png \
+            -tile 5x1 -geometry 300x+20+20 \
+            -background '#f5f5f5' -pointsize 18 \
+            screenshots/board.png
+
       - name: Upload screenshots artifact
         uses: actions/upload-artifact@v4
         with:
           name: ios-screenshots
-          path: ios/screenshots/*.png
+          path: |
+            ios/screenshots/board.png
+            ios/screenshots/0*.png
           retention-days: 10
 
       - name: Push screenshots to branch


### PR DESCRIPTION
## Summary
- `workflow_dispatch` トリガー追加で Actions 画面から手動スクショ実行可能に
- スクショを Artifact としてアップロード（retention: 10日）
- PR コメント・ブランチ push 等の PR 固有ステップは `pull_request` 時のみ実行

## Test plan
- [ ] Actions 画面から手動実行でスクショが Artifact に保存されること
- [ ] PR + `screenshots` ラベルで従来通りコメントにスクショが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)