### PR TITLE
dev.rikako.jp ドメイン設定（Route 53 + CloudFront + ACM）

### DIFF
--- a/.github/workflows/deploy-admin-frontend-dev.yml
+++ b/.github/workflows/deploy-admin-frontend-dev.yml
@@ -15,7 +15,7 @@ permissions:
 env:
   AWS_REGION: ap-northeast-1
   S3_BUCKET: rikako-admin-development
-  CLOUDFRONT_DISTRIBUTION_ID: ""
+  CLOUDFRONT_DISTRIBUTION_ID: "EIA13UUJ41NKO"
 
 jobs:
   build-and-deploy:

--- a/terraform/environments/dev/admin_frontend.tf
+++ b/terraform/environments/dev/admin_frontend.tf
@@ -40,6 +40,25 @@ resource "aws_cloudfront_function" "admin_api_rewrite" {
   EOF
 }
 
+# CloudFront Function to append index.html for subdirectory requests
+resource "aws_cloudfront_function" "admin_spa_rewrite" {
+  name    = "${local.project}-admin-spa-rewrite-${local.environment}"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = <<-EOF
+    function handler(event) {
+      var request = event.request;
+      var uri = request.uri;
+      if (uri.endsWith('/')) {
+        request.uri = uri + 'index.html';
+      } else if (!uri.includes('.')) {
+        request.uri = uri + '/index.html';
+      }
+      return request;
+    }
+  EOF
+}
+
 # CloudFront Distribution for admin (frontend + API)
 resource "aws_cloudfront_distribution" "admin" {
   # Origin 1: S3 (frontend static files)
@@ -66,6 +85,7 @@ resource "aws_cloudfront_distribution" "admin" {
   is_ipv6_enabled     = true
   comment             = "Admin (frontend + API) for ${local.project}-${local.environment}"
   default_root_object = "index.html"
+  aliases             = ["admin.dev.rikako.jp"]
 
   # Default: S3 frontend
   default_cache_behavior {
@@ -85,6 +105,11 @@ resource "aws_cloudfront_distribution" "admin" {
     min_ttl     = 0
     default_ttl = 86400
     max_ttl     = 31536000
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.admin_spa_rewrite.arn
+    }
   }
 
   # /api/* → Lambda admin API (with path rewrite)
@@ -134,7 +159,9 @@ resource "aws_cloudfront_distribution" "admin" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn      = aws_acm_certificate_validation.wildcard.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
   }
 
   tags = {

--- a/terraform/environments/dev/dns.tf
+++ b/terraform/environments/dev/dns.tf
@@ -1,0 +1,157 @@
+# =============================================================================
+# Route 53 Hosted Zone for dev.rikako.jp
+# =============================================================================
+
+resource "aws_route53_zone" "dev" {
+  name = "dev.rikako.jp"
+}
+
+# =============================================================================
+# ACM Wildcard Certificate (us-east-1, required for CloudFront)
+# =============================================================================
+
+resource "aws_acm_certificate" "wildcard" {
+  provider          = aws.us_east_1
+  domain_name       = "*.dev.rikako.jp"
+  validation_method = "DNS"
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.wildcard.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = aws_route53_zone.dev.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 300
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "wildcard" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.wildcard.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# =============================================================================
+# CloudFront Distribution for Public API (api.dev.rikako.jp)
+# =============================================================================
+
+locals {
+  api_origin_domain = trimsuffix(trimprefix(module.lambda.function_url, "https://"), "/")
+}
+
+resource "aws_cloudfront_distribution" "api" {
+  origin {
+    domain_name = local.api_origin_domain
+    origin_id   = "lambda-api"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "Public API for ${local.project}-${local.environment}"
+  aliases         = ["api.dev.rikako.jp"]
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "lambda-api"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers", "Authorization"]
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.wildcard.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# =============================================================================
+# Route 53 Records (A Alias → CloudFront)
+# =============================================================================
+
+# api.dev.rikako.jp → Public API CloudFront
+resource "aws_route53_record" "api" {
+  zone_id = aws_route53_zone.dev.zone_id
+  name    = "api.dev.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.api.domain_name
+    zone_id                = aws_cloudfront_distribution.api.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# image.dev.rikako.jp → Image CDN CloudFront
+resource "aws_route53_record" "image" {
+  zone_id = aws_route53_zone.dev.zone_id
+  name    = "image.dev.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = module.image_cloudfront.domain_name
+    zone_id                = "Z2FDTNDATAQYW2" # CloudFront global hosted zone ID
+    evaluate_target_health = false
+  }
+}
+
+# admin.dev.rikako.jp → Admin Frontend CloudFront
+resource "aws_route53_record" "admin" {
+  zone_id = aws_route53_zone.dev.zone_id
+  name    = "admin.dev.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.admin.domain_name
+    zone_id                = aws_cloudfront_distribution.admin.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/environments/dev/image_cdn.tf
+++ b/terraform/environments/dev/image_cdn.tf
@@ -22,6 +22,8 @@ module "image_cloudfront" {
   origin_domain_name = module.image_s3.bucket_regional_domain_name
   origin_id          = "s3-${local.image_bucket_name}"
   comment            = "Image CDN for ${local.image_bucket_name}"
+  aliases            = ["image.dev.rikako.jp"]
+  acm_certificate_arn = aws_acm_certificate_validation.wildcard.certificate_arn
 
   tags = {
     Project     = local.project

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -54,3 +54,8 @@ output "admin_frontend_bucket" {
   description = "S3 bucket for admin frontend"
   value       = module.admin_s3.bucket_id
 }
+
+output "dev_zone_name_servers" {
+  description = "Name servers for dev.rikako.jp (set these as NS records at parent domain)"
+  value       = aws_route53_zone.dev.name_servers
+}

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -17,6 +17,12 @@ provider "aws" {
   region = "ap-northeast-1"
 }
 
+# CloudFront requires ACM certificates in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
 data "aws_ssm_parameter" "neon_api_key" {
   name = "/rikako/neon-api-key"
 }

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -15,6 +15,7 @@ resource "aws_cloudfront_distribution" "this" {
   enabled         = true
   is_ipv6_enabled = true
   comment         = var.comment
+  aliases         = var.aliases
 
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD"]
@@ -42,7 +43,10 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = var.acm_certificate_arn == "" ? true : false
+    acm_certificate_arn            = var.acm_certificate_arn != "" ? var.acm_certificate_arn : null
+    ssl_support_method             = var.acm_certificate_arn != "" ? "sni-only" : null
+    minimum_protocol_version       = var.acm_certificate_arn != "" ? "TLSv1.2_2021" : null
   }
 
   tags = var.tags

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -31,6 +31,18 @@ variable "max_ttl" {
   default     = 31536000
 }
 
+variable "aliases" {
+  description = "CNAMEs (alternate domain names) for the distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for custom domain (must be in us-east-1)"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- Route 53 ホストゾーン (`dev.rikako.jp`) + ACM ワイルドカード証明書 (`*.dev.rikako.jp`)
- 公開API用 CloudFront を新規作成し `api.dev.rikako.jp` を設定
- 既存の Image CDN / Admin Frontend CloudFront にカスタムドメイン (`image.dev.rikako.jp`, `admin.dev.rikako.jp`) を追加
- SPA サブディレクトリの index.html 補完用 CloudFront Function を追加
- `deploy-admin-frontend` ワークフローに CloudFront Distribution ID を設定

## ドメインマッピング
| サブドメイン | 用途 |
|---|---|
| `api.dev.rikako.jp` | 公開API (CloudFront → Lambda) |
| `image.dev.rikako.jp` | 画像配信CDN (CloudFront → S3) |
| `admin.dev.rikako.jp` | 管理画面 (CloudFront → S3 + Lambda) |

## Test plan
- [x] `admin.dev.rikako.jp` にアクセスして管理画面が表示されること
- [ ] `api.dev.rikako.jp/health` でヘルスチェックが通ること
- [ ] `image.dev.rikako.jp` で画像が配信されること

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)