### PR TITLE
data/ 変更時に datasync plan を PR コメントに表示する CI を追加

### DIFF
--- a/.github/workflows/datasync-plan.yml
+++ b/.github/workflows/datasync-plan.yml
@@ -1,0 +1,85 @@
+name: Data Sync Plan
+
+on:
+  pull_request:
+    paths:
+      - "data/**"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  plan:
+    name: datasync plan (dev)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: app/go.mod
+          cache-dependency-path: app/go.sum
+
+      - name: Build datasync
+        working-directory: app
+        run: go build -o datasync ./cmd/datasync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          aws-region: ap-northeast-1
+
+      - name: Run datasync plan
+        id: plan
+        working-directory: app
+        run: |
+          OUTPUT=$(./datasync -data ../data -env dev plan 2>&1 | tail -n +2)
+          echo "result<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `### 📋 Data Sync Plan (dev)
+
+            \`\`\`
+            ${{ steps.plan.outputs.result }}
+            \`\`\`
+
+            > \`data/\` の変更による DB 差分です。反映するには \`datasync apply\` を手動実行してください。
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Data Sync Plan')
+            );
+
+            const body = output.replace(/^ {12}/gm, '');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

- `data/` 配下を変更する PR で自動的に `datasync plan` を実行
- dev 環境（Neon DB）との差分を PR コメントに表示（terraform plan と同じパターン）
- apply は手動のまま（安全のため）

Closes #51

## Test plan

- [ ] `data/` を変更する PR を作成し、plan コメントが付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)