### PR TITLE
管理APIにコンテンツJSON書き出し機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ cd app && oapi-codegen --config oapi-codegen-admin.yaml ../openapi-admin.yaml
 cd app && go test ./internal/admin/
 ```
 
-環境変数: `DATABASE_URL`, `IMAGE_BASE_URL`, `IMAGE_S3_BUCKET`, `AWS_REGION`, `PORT`(デフォルト: 8081)
+環境変数: `DATABASE_URL`, `IMAGE_BASE_URL`, `IMAGE_S3_BUCKET`, `CONTENT_S3_BUCKET`, `AWS_REGION`, `PORT`(デフォルト: 8081)
 
 ### Terraform操作
 ```bash
@@ -212,6 +212,8 @@ db.SetConnMaxIdleTime(1 * time.Minute)  // アイドル接続の最大時間
 - **Dev環境**
   - Lambda Function URL: https://umay5vbvquds44pubogp2jpaky0okiaj.lambda-url.ap-northeast-1.on.aws/
   - Image CDN: https://d1ovm6exq28tn1.cloudfront.net/
+  - Content CDN: https://content.dev.rikako.jp/ （静的JSON配信）
+  - Content S3: rikako-content-development
   - Image S3: rikako-images-development
   - Neon DB: muddy-tree-64549662 (ap-southeast-1)
   - Cognito User Pool: Terraform管理（rikako-development）
@@ -238,6 +240,28 @@ db.SetConnMaxIdleTime(1 * time.Minute)  // アイドル接続の最大時間
    - 環境選択（dev/prod）
    - 方向選択（up/down）
    - ステップ数指定
+
+## コンテンツ配信（S3 + CloudFront）
+
+iOSアプリはLambda APIではなく、S3上の静的JSONをCloudFront経由で取得する。
+
+### 配信フロー
+1. `data/` のYAMLを編集
+2. `cd app && go run ./cmd/importer -data ../data` でDBに同期
+3. `curl -X POST https://admin.dev.rikako.jp/publish` でDB → S3にJSON書き出し
+4. CloudFrontが60秒以内に新JSONを配信
+
+### S3上のJSON構造
+```
+s3://rikako-content-development/
+  v1/
+    workbooks.json                # 問題集一覧
+    workbooks/{id}.json           # 問題集詳細（問題含む）
+    categories.json               # カテゴリ一覧
+    categories/{id}.json          # カテゴリ詳細（問題集含む）
+```
+
+JSON形式は公開API（openapi.yaml）のレスポンスと完全一致。
 
 ## 注意事項
 

--- a/app/cmd/admin/main.go
+++ b/app/cmd/admin/main.go
@@ -72,8 +72,11 @@ func main() {
 	// カスタムエラーハンドラ
 	e.HTTPErrorHandler = newHTTPErrorHandler(logger)
 
+	// コンテンツS3バケット
+	contentS3Bucket := os.Getenv("CONTENT_S3_BUCKET")
+
 	// ハンドラー登録（認証なし）
-	h := admin.New(db, imageBaseURL, s3Client, s3Bucket, logger)
+	h := admin.New(db, imageBaseURL, s3Client, s3Bucket, contentS3Bucket, logger)
 	strictHandler := adminapi.NewStrictHandler(h, nil)
 	adminapi.RegisterHandlers(e, strictHandler)
 

--- a/app/internal/admin/handler.go
+++ b/app/internal/admin/handler.go
@@ -14,20 +14,22 @@ import (
 )
 
 type Handler struct {
-	db           *sql.DB
-	imageBaseURL string
-	s3Client     *s3.Client
-	s3Bucket     string
-	logger       *slog.Logger
+	db              *sql.DB
+	imageBaseURL    string
+	s3Client        *s3.Client
+	s3Bucket        string
+	contentS3Bucket string
+	logger          *slog.Logger
 }
 
-func New(db *sql.DB, imageBaseURL string, s3Client *s3.Client, s3Bucket string, logger *slog.Logger) *Handler {
+func New(db *sql.DB, imageBaseURL string, s3Client *s3.Client, s3Bucket string, contentS3Bucket string, logger *slog.Logger) *Handler {
 	return &Handler{
-		db:           db,
-		imageBaseURL: imageBaseURL,
-		s3Client:     s3Client,
-		s3Bucket:     s3Bucket,
-		logger:       logger,
+		db:              db,
+		imageBaseURL:    imageBaseURL,
+		s3Client:        s3Client,
+		s3Bucket:        s3Bucket,
+		contentS3Bucket: contentS3Bucket,
+		logger:          logger,
 	}
 }
 

--- a/app/internal/admin/handler_test.go
+++ b/app/internal/admin/handler_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestHandler() *Handler {
-	return New(testDB, "https://example.com", nil, "", testLogger)
+	return New(testDB, "https://example.com", nil, "", "", testLogger)
 }
 
 func TestRoot(t *testing.T) {

--- a/app/internal/admin/publisher.go
+++ b/app/internal/admin/publisher.go
@@ -1,0 +1,388 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/lib/pq"
+	"github.com/takoikatakotako/rikako/internal/adminapi"
+	"github.com/takoikatakotako/rikako/internal/api"
+)
+
+func (h *Handler) PostPublish(ctx context.Context, _ adminapi.PostPublishRequestObject) (adminapi.PostPublishResponseObject, error) {
+	if h.s3Client == nil || h.contentS3Bucket == "" {
+		return adminapi.PostPublish500JSONResponse{
+			Code:    "NOT_CONFIGURED",
+			Message: "content S3 bucket is not configured",
+		}, nil
+	}
+
+	// カテゴリ一覧を生成・アップロード
+	categories, err := h.buildCategories(ctx)
+	if err != nil {
+		h.logger.Error("failed to build categories", "error", err)
+		return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: "failed to build categories"}, nil
+	}
+
+	categoriesResp := api.CategoriesResponse{
+		Categories: categories,
+		Total:      len(categories),
+	}
+	if err := h.uploadJSON(ctx, "v1/categories.json", categoriesResp); err != nil {
+		h.logger.Error("failed to upload categories.json", "error", err)
+		return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: "failed to upload categories.json"}, nil
+	}
+
+	// カテゴリ詳細を生成・アップロード
+	for _, c := range categories {
+		detail, err := h.buildCategoryDetail(ctx, c.Id)
+		if err != nil {
+			h.logger.Error("failed to build category detail", "error", err, "category_id", c.Id)
+			return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: fmt.Sprintf("failed to build category %d", c.Id)}, nil
+		}
+		if err := h.uploadJSON(ctx, fmt.Sprintf("v1/categories/%d.json", c.Id), detail); err != nil {
+			h.logger.Error("failed to upload category detail", "error", err, "category_id", c.Id)
+			return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: fmt.Sprintf("failed to upload category %d", c.Id)}, nil
+		}
+	}
+
+	// ワークブック一覧を生成・アップロード
+	workbooks, err := h.buildWorkbooks(ctx)
+	if err != nil {
+		h.logger.Error("failed to build workbooks", "error", err)
+		return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: "failed to build workbooks"}, nil
+	}
+
+	workbooksResp := api.WorkbooksResponse{
+		Workbooks: workbooks,
+		Total:     len(workbooks),
+	}
+	if err := h.uploadJSON(ctx, "v1/workbooks.json", workbooksResp); err != nil {
+		h.logger.Error("failed to upload workbooks.json", "error", err)
+		return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: "failed to upload workbooks.json"}, nil
+	}
+
+	// ワークブック詳細を生成・アップロード
+	for _, w := range workbooks {
+		detail, err := h.buildWorkbookDetail(ctx, w.Id)
+		if err != nil {
+			h.logger.Error("failed to build workbook detail", "error", err, "workbook_id", w.Id)
+			return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: fmt.Sprintf("failed to build workbook %d", w.Id)}, nil
+		}
+		if err := h.uploadJSON(ctx, fmt.Sprintf("v1/workbooks/%d.json", w.Id), detail); err != nil {
+			h.logger.Error("failed to upload workbook detail", "error", err, "workbook_id", w.Id)
+			return adminapi.PostPublish500JSONResponse{Code: "INTERNAL_ERROR", Message: fmt.Sprintf("failed to upload workbook %d", w.Id)}, nil
+		}
+	}
+
+	categoriesCount := len(categories)
+	workbooksCount := len(workbooks)
+	now := time.Now()
+
+	return adminapi.PostPublish200JSONResponse{
+		Message:         "published successfully",
+		PublishedAt:     now,
+		CategoriesCount: &categoriesCount,
+		WorkbooksCount:  &workbooksCount,
+	}, nil
+}
+
+func (h *Handler) uploadJSON(ctx context.Context, key string, data any) error {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal JSON: %w", err)
+	}
+
+	_, err = h.s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:       aws.String(h.contentS3Bucket),
+		Key:          aws.String(key),
+		Body:         bytes.NewReader(jsonBytes),
+		ContentType:  aws.String("application/json"),
+		CacheControl: aws.String("public, max-age=60"),
+	})
+	if err != nil {
+		return fmt.Errorf("put S3 object %s: %w", key, err)
+	}
+
+	h.logger.Info("uploaded JSON", "key", key, "size", len(jsonBytes))
+	return nil
+}
+
+func (h *Handler) buildCategories(ctx context.Context) ([]api.Category, error) {
+	rows, err := h.db.QueryContext(ctx, `
+		SELECT c.id, c.title, c.description,
+			(SELECT COUNT(*) FROM workbooks w WHERE w.category_id = c.id) as workbook_count
+		FROM categories c
+		ORDER BY c.id
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var categories []api.Category
+	for rows.Next() {
+		var id int64
+		var title string
+		var description sql.NullString
+		var workbookCount int
+
+		if err := rows.Scan(&id, &title, &description, &workbookCount); err != nil {
+			return nil, err
+		}
+
+		c := api.Category{
+			Id:            id,
+			Title:         title,
+			WorkbookCount: &workbookCount,
+		}
+		if description.Valid {
+			c.Description = &description.String
+		}
+		categories = append(categories, c)
+	}
+
+	if categories == nil {
+		categories = []api.Category{}
+	}
+	return categories, nil
+}
+
+func (h *Handler) buildCategoryDetail(ctx context.Context, categoryID int64) (api.CategoryDetail, error) {
+	var title string
+	var description sql.NullString
+
+	err := h.db.QueryRowContext(ctx, `
+		SELECT title, description FROM categories WHERE id = $1
+	`, categoryID).Scan(&title, &description)
+	if err != nil {
+		return api.CategoryDetail{}, err
+	}
+
+	rows, err := h.db.QueryContext(ctx, `
+		SELECT w.id, w.title, w.description,
+			(SELECT COUNT(*) FROM workbook_questions wq WHERE wq.workbook_id = w.id) as question_count
+		FROM workbooks w
+		WHERE w.category_id = $1
+		ORDER BY w.id
+	`, categoryID)
+	if err != nil {
+		return api.CategoryDetail{}, err
+	}
+	defer rows.Close()
+
+	var workbooks []api.Workbook
+	for rows.Next() {
+		var wid int64
+		var wtitle string
+		var wdesc sql.NullString
+		var questionCount int
+
+		if err := rows.Scan(&wid, &wtitle, &wdesc, &questionCount); err != nil {
+			return api.CategoryDetail{}, err
+		}
+
+		w := api.Workbook{
+			Id:            wid,
+			Title:         wtitle,
+			QuestionCount: &questionCount,
+			CategoryId:    &categoryID,
+		}
+		if wdesc.Valid {
+			w.Description = &wdesc.String
+		}
+		workbooks = append(workbooks, w)
+	}
+
+	if workbooks == nil {
+		workbooks = []api.Workbook{}
+	}
+
+	detail := api.CategoryDetail{
+		Id:        categoryID,
+		Title:     title,
+		Workbooks: workbooks,
+	}
+	if description.Valid {
+		detail.Description = &description.String
+	}
+	return detail, nil
+}
+
+func (h *Handler) buildWorkbooks(ctx context.Context) ([]api.Workbook, error) {
+	rows, err := h.db.QueryContext(ctx, `
+		SELECT w.id, w.title, w.description, w.category_id,
+			(SELECT COUNT(*) FROM workbook_questions wq WHERE wq.workbook_id = w.id) as question_count
+		FROM workbooks w
+		ORDER BY w.id
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var workbooks []api.Workbook
+	for rows.Next() {
+		var id int64
+		var title string
+		var description sql.NullString
+		var categoryID sql.NullInt64
+		var questionCount int
+
+		if err := rows.Scan(&id, &title, &description, &categoryID, &questionCount); err != nil {
+			return nil, err
+		}
+
+		w := api.Workbook{
+			Id:            id,
+			Title:         title,
+			QuestionCount: &questionCount,
+		}
+		if description.Valid {
+			w.Description = &description.String
+		}
+		if categoryID.Valid {
+			cid := categoryID.Int64
+			w.CategoryId = &cid
+		}
+		workbooks = append(workbooks, w)
+	}
+
+	if workbooks == nil {
+		workbooks = []api.Workbook{}
+	}
+	return workbooks, nil
+}
+
+func (h *Handler) buildWorkbookDetail(ctx context.Context, workbookID int64) (api.WorkbookDetail, error) {
+	var title string
+	var description sql.NullString
+	var categoryID sql.NullInt64
+
+	err := h.db.QueryRowContext(ctx, `
+		SELECT title, description, category_id FROM workbooks WHERE id = $1
+	`, workbookID).Scan(&title, &description, &categoryID)
+	if err != nil {
+		return api.WorkbookDetail{}, err
+	}
+
+	// 問題・選択肢・正解を1クエリで一括取得
+	rows, err := h.db.QueryContext(ctx, `
+		SELECT q.id, qsc.text, qsc.explanation,
+			c.text AS choice_text, c.is_correct, c.choice_index
+		FROM questions q
+		JOIN questions_single_choice qsc ON q.id = qsc.question_id
+		JOIN workbook_questions wq ON q.id = wq.question_id
+		LEFT JOIN questions_single_choice_choices c
+			ON c.single_choice_id = qsc.id
+		WHERE wq.workbook_id = $1
+		ORDER BY wq.order_index, c.choice_index
+	`, workbookID)
+	if err != nil {
+		return api.WorkbookDetail{}, err
+	}
+	defer rows.Close()
+
+	type questionData struct {
+		question api.Question
+		order    int
+	}
+	questionsMap := map[int64]*questionData{}
+	var questionOrder []int64
+	orderIdx := 0
+
+	for rows.Next() {
+		var qid int64
+		var text string
+		var explanation sql.NullString
+		var choiceText sql.NullString
+		var isCorrect sql.NullBool
+		var choiceIndex sql.NullInt64
+
+		if err := rows.Scan(&qid, &text, &explanation, &choiceText, &isCorrect, &choiceIndex); err != nil {
+			return api.WorkbookDetail{}, err
+		}
+
+		qd, exists := questionsMap[qid]
+		if !exists {
+			q := api.Question{
+				Id:   qid,
+				Type: api.SingleChoice,
+				Text: text,
+			}
+			if explanation.Valid {
+				q.Explanation = &explanation.String
+			}
+			qd = &questionData{question: q, order: orderIdx}
+			questionsMap[qid] = qd
+			questionOrder = append(questionOrder, qid)
+			orderIdx++
+		}
+
+		if choiceText.Valid {
+			qd.question.Choices = append(qd.question.Choices, choiceText.String)
+			if isCorrect.Valid && isCorrect.Bool {
+				idx := int(choiceIndex.Int64)
+				qd.question.Correct = &idx
+			}
+		}
+	}
+
+	// 画像を一括取得
+	if len(questionOrder) > 0 {
+		imageRows, err := h.db.QueryContext(ctx, `
+			SELECT qi.question_id, i.path
+			FROM question_images qi
+			JOIN images i ON i.id = qi.image_id
+			WHERE qi.question_id = ANY($1)
+			ORDER BY qi.question_id, qi.order_index
+		`, pq.Array(questionOrder))
+		if err != nil {
+			return api.WorkbookDetail{}, err
+		}
+		defer imageRows.Close()
+
+		for imageRows.Next() {
+			var qid int64
+			var path string
+			if err := imageRows.Scan(&qid, &path); err != nil {
+				return api.WorkbookDetail{}, err
+			}
+			if qd, ok := questionsMap[qid]; ok {
+				url := fmt.Sprintf("%s/%s", h.imageBaseURL, path)
+				if qd.question.Images == nil {
+					urls := []string{url}
+					qd.question.Images = &urls
+				} else {
+					*qd.question.Images = append(*qd.question.Images, url)
+				}
+			}
+		}
+	}
+
+	// 順序通りに組み立て
+	questions := make([]api.Question, 0, len(questionOrder))
+	for _, qid := range questionOrder {
+		questions = append(questions, questionsMap[qid].question)
+	}
+
+	detail := api.WorkbookDetail{
+		Id:        workbookID,
+		Title:     title,
+		Questions: questions,
+	}
+	if description.Valid {
+		detail.Description = &description.String
+	}
+	if categoryID.Valid {
+		cid := categoryID.Int64
+		detail.CategoryId = &cid
+	}
+	return detail, nil
+}

--- a/app/internal/admin/publisher_test.go
+++ b/app/internal/admin/publisher_test.go
@@ -1,0 +1,183 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/takoikatakotako/rikako/internal/adminapi"
+	"github.com/takoikatakotako/rikako/internal/api"
+)
+
+func TestPostPublish_NoS3(t *testing.T) {
+	h := newTestHandler()
+	resp, err := h.PostPublish(context.Background(), adminapi.PostPublishRequestObject{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	errResp, ok := resp.(adminapi.PostPublish500JSONResponse)
+	if !ok {
+		t.Fatalf("expected PostPublish500JSONResponse, got %T", resp)
+	}
+	if errResp.Code != "NOT_CONFIGURED" {
+		t.Errorf("expected code NOT_CONFIGURED, got %s", errResp.Code)
+	}
+}
+
+func TestBuildCategories(t *testing.T) {
+	h := newTestHandler()
+	ctx := context.Background()
+
+	categories, err := h.buildCategories(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify JSON serialization matches public API format
+	data, err := json.Marshal(api.CategoriesResponse{
+		Categories: categories,
+		Total:      len(categories),
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if _, ok := result["categories"]; !ok {
+		t.Error("expected 'categories' field in JSON")
+	}
+	if _, ok := result["total"]; !ok {
+		t.Error("expected 'total' field in JSON")
+	}
+}
+
+func TestBuildWorkbooks(t *testing.T) {
+	h := newTestHandler()
+	ctx := context.Background()
+
+	workbooks, err := h.buildWorkbooks(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify JSON serialization matches public API format
+	data, err := json.Marshal(api.WorkbooksResponse{
+		Workbooks: workbooks,
+		Total:     len(workbooks),
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if _, ok := result["workbooks"]; !ok {
+		t.Error("expected 'workbooks' field in JSON")
+	}
+	if _, ok := result["total"]; !ok {
+		t.Error("expected 'total' field in JSON")
+	}
+}
+
+func TestBuildWorkbookDetail_JSONFormat(t *testing.T) {
+	h := newTestHandler()
+	ctx := context.Background()
+
+	// First create test data
+	catReq := adminapi.CreateCategoryRequestObject{
+		Body: &adminapi.CreateCategoryRequest{Title: "Test Category for Publish"},
+	}
+	catResp, err := h.CreateCategory(ctx, catReq)
+	if err != nil {
+		t.Fatalf("failed to create category: %v", err)
+	}
+	cat := catResp.(adminapi.CreateCategory201JSONResponse)
+	categoryID := cat.Id
+
+	qReq := adminapi.CreateQuestionRequestObject{
+		Body: &adminapi.CreateQuestionRequest{
+			Type: adminapi.CreateQuestionRequestTypeSingleChoice,
+			Text: "Publish test question",
+			Choices: []adminapi.Choice{
+				{Text: "A", IsCorrect: true},
+				{Text: "B", IsCorrect: false},
+			},
+		},
+	}
+	qResp, err := h.CreateQuestion(ctx, qReq)
+	if err != nil {
+		t.Fatalf("failed to create question: %v", err)
+	}
+	q := qResp.(adminapi.CreateQuestion201JSONResponse)
+
+	wReq := adminapi.CreateWorkbookRequestObject{
+		Body: &adminapi.CreateWorkbookRequest{
+			Title:       "Publish Test Workbook",
+			CategoryId:  &categoryID,
+			QuestionIds: &[]int64{q.Id},
+		},
+	}
+	wResp, err := h.CreateWorkbook(ctx, wReq)
+	if err != nil {
+		t.Fatalf("failed to create workbook: %v", err)
+	}
+	wb := wResp.(adminapi.CreateWorkbook201JSONResponse)
+
+	// Build workbook detail
+	detail, err := h.buildWorkbookDetail(ctx, wb.Id)
+	if err != nil {
+		t.Fatalf("failed to build workbook detail: %v", err)
+	}
+
+	// Verify JSON matches iOS Models.swift expected format
+	data, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Check required fields
+	for _, field := range []string{"id", "title", "questions", "categoryId"} {
+		if _, ok := result[field]; !ok {
+			t.Errorf("expected '%s' field in WorkbookDetail JSON", field)
+		}
+	}
+
+	// Check question format (public API: choices as []string, correct as int)
+	questions, ok := result["questions"].([]interface{})
+	if !ok || len(questions) == 0 {
+		t.Fatal("expected non-empty questions array")
+	}
+
+	question := questions[0].(map[string]interface{})
+	if _, ok := question["choices"]; !ok {
+		t.Error("expected 'choices' in question")
+	}
+	// choices should be []string, not []Choice
+	choices, ok := question["choices"].([]interface{})
+	if !ok {
+		t.Fatal("expected choices to be an array")
+	}
+	if _, ok := choices[0].(string); !ok {
+		t.Error("expected choices to be strings (public API format), not objects (admin API format)")
+	}
+	if _, ok := question["correct"]; !ok {
+		t.Error("expected 'correct' field in question")
+	}
+
+	// Cleanup
+	h.DeleteWorkbook(ctx, adminapi.DeleteWorkbookRequestObject{WorkbookId: wb.Id})
+	h.DeleteQuestion(ctx, adminapi.DeleteQuestionRequestObject{QuestionId: q.Id})
+	h.DeleteCategory(ctx, adminapi.DeleteCategoryRequestObject{CategoryId: categoryID})
+}

--- a/app/internal/adminapi/api.gen.go
+++ b/app/internal/adminapi/api.gen.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/oapi-codegen/runtime"
@@ -163,6 +164,14 @@ type PresignedUrlResponse struct {
 	UploadUrl string `json:"uploadUrl"`
 }
 
+// PublishResponse defines model for PublishResponse.
+type PublishResponse struct {
+	CategoriesCount *int      `json:"categoriesCount,omitempty"`
+	Message         string    `json:"message"`
+	PublishedAt     time.Time `json:"publishedAt"`
+	WorkbooksCount  *int      `json:"workbooksCount,omitempty"`
+}
+
 // Question defines model for Question.
 type Question struct {
 	Choices     []Choice     `json:"choices"`
@@ -297,6 +306,9 @@ type ServerInterface interface {
 	// 画像アップロード用Presigned URL発行
 	// (POST /images/presigned-url)
 	CreatePresignedUrl(ctx echo.Context) error
+	// コンテンツをS3にJSON書き出し
+	// (POST /publish)
+	PostPublish(ctx echo.Context) error
 	// 問題一覧取得
 	// (GET /questions)
 	GetQuestions(ctx echo.Context, params GetQuestionsParams) error
@@ -440,6 +452,15 @@ func (w *ServerInterfaceWrapper) CreatePresignedUrl(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.CreatePresignedUrl(ctx)
+	return err
+}
+
+// PostPublish converts echo context to params.
+func (w *ServerInterfaceWrapper) PostPublish(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.PostPublish(ctx)
 	return err
 }
 
@@ -643,6 +664,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PUT(baseURL+"/categories/:categoryId", wrapper.UpdateCategory)
 	router.GET(baseURL+"/health", wrapper.HealthCheck)
 	router.POST(baseURL+"/images/presigned-url", wrapper.CreatePresignedUrl)
+	router.POST(baseURL+"/publish", wrapper.PostPublish)
 	router.GET(baseURL+"/questions", wrapper.GetQuestions)
 	router.POST(baseURL+"/questions", wrapper.CreateQuestion)
 	router.DELETE(baseURL+"/questions/:questionId", wrapper.DeleteQuestion)
@@ -849,6 +871,31 @@ type CreatePresignedUrl400JSONResponse Error
 func (response CreatePresignedUrl400JSONResponse) VisitCreatePresignedUrlResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostPublishRequestObject struct {
+}
+
+type PostPublishResponseObject interface {
+	VisitPostPublishResponse(w http.ResponseWriter) error
+}
+
+type PostPublish200JSONResponse PublishResponse
+
+func (response PostPublish200JSONResponse) VisitPostPublishResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostPublish500JSONResponse Error
+
+func (response PostPublish500JSONResponse) VisitPostPublishResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -1157,6 +1204,9 @@ type StrictServerInterface interface {
 	// 画像アップロード用Presigned URL発行
 	// (POST /images/presigned-url)
 	CreatePresignedUrl(ctx context.Context, request CreatePresignedUrlRequestObject) (CreatePresignedUrlResponseObject, error)
+	// コンテンツをS3にJSON書き出し
+	// (POST /publish)
+	PostPublish(ctx context.Context, request PostPublishRequestObject) (PostPublishResponseObject, error)
 	// 問題一覧取得
 	// (GET /questions)
 	GetQuestions(ctx context.Context, request GetQuestionsRequestObject) (GetQuestionsResponseObject, error)
@@ -1405,6 +1455,29 @@ func (sh *strictHandler) CreatePresignedUrl(ctx echo.Context) error {
 		return err
 	} else if validResponse, ok := response.(CreatePresignedUrlResponseObject); ok {
 		return validResponse.VisitCreatePresignedUrlResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// PostPublish operation middleware
+func (sh *strictHandler) PostPublish(ctx echo.Context) error {
+	var request PostPublishRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostPublish(ctx.Request().Context(), request.(PostPublishRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostPublish")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(PostPublishResponseObject); ok {
+		return validResponse.VisitPostPublishResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/ios/Rikako/APIClient.swift
+++ b/ios/Rikako/APIClient.swift
@@ -8,24 +8,21 @@ final class APIClient {
     private let decoder: JSONDecoder
 
     private init() {
-        self.baseURL = URL(string: "https://umay5vbvquds44pubogp2jpaky0okiaj.lambda-url.ap-northeast-1.on.aws")!
+        self.baseURL = URL(string: "https://content.dev.rikako.jp/v1")!
         self.session = .shared
         self.decoder = JSONDecoder()
     }
 
     func fetchWorkbooks() async throws -> [Workbook] {
-        let url = baseURL.appendingPathComponent("workbooks")
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-        components.queryItems = [URLQueryItem(name: "limit", value: "100")]
-
-        let (data, response) = try await session.data(from: components.url!)
+        let url = baseURL.appendingPathComponent("workbooks.json")
+        let (data, response) = try await session.data(from: url)
         try validateResponse(response)
         let result = try decoder.decode(WorkbooksResponse.self, from: data)
         return result.workbooks
     }
 
     func fetchWorkbookDetail(id: Int64) async throws -> WorkbookDetail {
-        let url = baseURL.appendingPathComponent("workbooks/\(id)")
+        let url = baseURL.appendingPathComponent("workbooks/\(id).json")
         let (data, response) = try await session.data(from: url)
         try validateResponse(response)
         return try decoder.decode(WorkbookDetail.self, from: data)

--- a/openapi-admin.yaml
+++ b/openapi-admin.yaml
@@ -466,6 +466,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /publish:
+    post:
+      summary: コンテンツをS3にJSON書き出し
+      operationId: postPublish
+      tags:
+        - Publish
+      responses:
+        '200':
+          description: 書き出し成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublishResponse'
+        '500':
+          description: 書き出しエラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /images/presigned-url:
     post:
       summary: 画像アップロード用Presigned URL発行
@@ -803,6 +823,22 @@ components:
           format: int64
         cdnUrl:
           type: string
+
+    PublishResponse:
+      type: object
+      required:
+        - message
+        - publishedAt
+      properties:
+        message:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+        categoriesCount:
+          type: integer
+        workbooksCount:
+          type: integer
 
     Error:
       type: object

--- a/terraform/environments/dev/admin_api.tf
+++ b/terraform/environments/dev/admin_api.tf
@@ -16,3 +16,23 @@ data "aws_iam_policy_document" "lambda_admin_s3_presign" {
     ]
   }
 }
+
+# S3 access for Admin API Lambda (Content JSON publish)
+resource "aws_iam_role_policy" "lambda_admin_s3_content" {
+  name   = "s3-content-access"
+  role   = module.lambda_admin.role_name
+  policy = data.aws_iam_policy_document.lambda_admin_s3_content.json
+}
+
+data "aws_iam_policy_document" "lambda_admin_s3_content" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${module.content_s3.bucket_arn}/*",
+    ]
+  }
+}

--- a/terraform/environments/dev/content_cdn.tf
+++ b/terraform/environments/dev/content_cdn.tf
@@ -1,0 +1,61 @@
+locals {
+  content_bucket_name = "${local.project}-content-${local.environment}"
+}
+
+# S3 Bucket for content JSON
+module "content_s3" {
+  source = "../../modules/s3"
+
+  bucket_name = local.content_bucket_name
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# CloudFront for content delivery
+module "content_cloudfront" {
+  source = "../../modules/cloudfront"
+
+  name               = local.content_bucket_name
+  origin_domain_name = module.content_s3.bucket_regional_domain_name
+  origin_id          = "s3-${local.content_bucket_name}"
+  comment            = "Content CDN for ${local.content_bucket_name}"
+  aliases            = ["content.dev.rikako.jp"]
+  acm_certificate_arn = aws_acm_certificate_validation.wildcard.certificate_arn
+  default_ttl        = 60
+  max_ttl            = 300
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# S3 Bucket Policy - Allow CloudFront access via OAC
+resource "aws_s3_bucket_policy" "content_cdn" {
+  bucket = module.content_s3.bucket_id
+  policy = data.aws_iam_policy_document.content_cdn_s3_access.json
+}
+
+data "aws_iam_policy_document" "content_cdn_s3_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${module.content_s3.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.content_cloudfront.distribution_arn]
+    }
+  }
+}

--- a/terraform/environments/dev/dns.tf
+++ b/terraform/environments/dev/dns.tf
@@ -143,6 +143,19 @@ resource "aws_route53_record" "image" {
   }
 }
 
+# content.dev.rikako.jp → Content CDN CloudFront
+resource "aws_route53_record" "content" {
+  zone_id = aws_route53_zone.dev.zone_id
+  name    = "content.dev.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = module.content_cloudfront.domain_name
+    zone_id                = "Z2FDTNDATAQYW2" # CloudFront global hosted zone ID
+    evaluate_target_health = false
+  }
+}
+
 # admin.dev.rikako.jp → Admin Frontend CloudFront
 resource "aws_route53_record" "admin" {
   zone_id = aws_route53_zone.dev.zone_id

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -45,6 +45,8 @@ module "lambda_admin" {
     ENVIRONMENT                       = local.environment
     IMAGE_BASE_URL                    = "https://${module.image_cloudfront.domain_name}"
     IMAGE_S3_BUCKET                   = local.image_bucket_name
+    CONTENT_S3_BUCKET                 = local.content_bucket_name
+    CONTENT_BASE_URL                  = "https://content.dev.rikako.jp"
     AWS_LWA_READINESS_CHECK_PROTOCOL  = "http"
     AWS_LWA_READINESS_CHECK_PORT      = "8080"
     AWS_LWA_READINESS_CHECK_PATH      = "/health"


### PR DESCRIPTION
## Summary
- 管理APIに `POST /publish` エンドポイントを追加。DB→S3にJSON書き出し→CloudFront配信
- iOSアプリをLambda API → CloudFront静的JSON取得に切り替え
- Terraform: content用S3バケット + CloudFront distribution + DNS + IAM追加

## 動作確認済み
- `POST /publish` → カテゴリ2件、問題集3件を書き出し成功
- `https://content.dev.rikako.jp/v1/workbooks.json` 等でJSON取得確認
- JSON形式がiOS Models.swiftと互換であることを確認

## Test plan
- [x] `go test ./internal/admin/` 全テストPASS
- [x] `go test ./...` 既存テスト含め全PASS
- [x] Terraform apply 完了（7 added, 1 changed）
- [x] Admin API デプロイ + ヘルスチェック成功
- [x] `POST /publish` でS3書き出し成功
- [x] CloudFront経由でJSON取得確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)