### PR TITLE
管理画面にコンテンツ出力ボタンを追加

### DIFF
--- a/admin/src/components/layout/sidebar.tsx
+++ b/admin/src/components/layout/sidebar.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BookOpen, FileQuestion, FolderOpen } from "lucide-react";
+import { BookOpen, FileQuestion, FolderOpen, Upload, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { apiPost } from "@/lib/api/client";
+import type { PublishResponse } from "@/lib/api/types";
 
 const navigation = [
   { name: "カテゴリ", href: "/categories", icon: FolderOpen },
@@ -13,6 +17,21 @@ const navigation = [
 
 export function Sidebar() {
   const pathname = usePathname();
+  const [publishing, setPublishing] = useState(false);
+
+  const handlePublish = async () => {
+    setPublishing(true);
+    try {
+      const result = await apiPost<PublishResponse>("/publish", {});
+      toast.success(
+        `出力完了: カテゴリ ${result.categoriesCount}件、問題集 ${result.workbooksCount}件`,
+      );
+    } catch {
+      toast.error("出力に失敗しました");
+    } finally {
+      setPublishing(false);
+    }
+  };
 
   return (
     <aside className="flex h-screen w-60 flex-col border-r bg-background">
@@ -41,6 +60,24 @@ export function Sidebar() {
           );
         })}
       </nav>
+      <div className="border-t p-2">
+        <button
+          onClick={handlePublish}
+          disabled={publishing}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            "disabled:pointer-events-none disabled:opacity-50",
+          )}
+        >
+          {publishing ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Upload className="h-4 w-4" />
+          )}
+          {publishing ? "出力中..." : "コンテンツ出力"}
+        </button>
+      </div>
     </aside>
   );
 }

--- a/admin/src/lib/api/types.ts
+++ b/admin/src/lib/api/types.ts
@@ -108,6 +108,13 @@ export interface PresignedUrlResponse {
   cdnUrl: string;
 }
 
+export interface PublishResponse {
+  message: string;
+  publishedAt: string;
+  categoriesCount?: number;
+  workbooksCount?: number;
+}
+
 export interface ApiError {
   code: string;
   message: string;


### PR DESCRIPTION
## Summary
- サイドバー下部に「コンテンツ出力」ボタンを追加
- `POST /publish` を呼び出してDB→S3へJSON書き出し
- 実行中はスピナー表示、完了/失敗時にトースト通知

## Test plan
- [x] `npm run build` 成功
- [ ] 管理画面でボタン押下 → トースト「出力完了」確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)