### PR TITLE
管理APIのLambda Function URLにOACを追加して直アクセスを防止

### DIFF
--- a/terraform/environments/dev/admin_frontend.tf
+++ b/terraform/environments/dev/admin_frontend.tf
@@ -32,6 +32,14 @@ resource "aws_cloudfront_origin_access_control" "admin" {
   signing_protocol                  = "sigv4"
 }
 
+# CloudFront OAC for admin API (Lambda)
+resource "aws_cloudfront_origin_access_control" "admin_api" {
+  name                              = "${local.project}-admin-api-${local.environment}"
+  origin_access_control_origin_type = "lambda"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
 # CloudFront Function for Basic Auth + SPA rewrite (frontend)
 resource "aws_cloudfront_function" "admin_spa_rewrite" {
   name    = "${local.project}-admin-spa-rewrite-${local.environment}"
@@ -102,10 +110,11 @@ resource "aws_cloudfront_distribution" "admin" {
     origin_access_control_id = aws_cloudfront_origin_access_control.admin.id
   }
 
-  # Origin 2: Lambda Function URL (admin API)
+  # Origin 2: Lambda Function URL (admin API) with OAC
   origin {
-    domain_name = local.admin_api_origin_domain
-    origin_id   = "lambda-admin-api"
+    domain_name              = local.admin_api_origin_domain
+    origin_id                = "lambda-admin-api"
+    origin_access_control_id = aws_cloudfront_origin_access_control.admin_api.id
 
     custom_origin_config {
       http_port              = 80
@@ -203,6 +212,15 @@ resource "aws_cloudfront_distribution" "admin" {
     Environment = local.environment
     ManagedBy   = "terraform"
   }
+}
+
+# Lambda Permission - Allow CloudFront to invoke admin API via OAC
+resource "aws_lambda_permission" "admin_cloudfront" {
+  statement_id  = "AllowCloudFrontInvoke"
+  action        = "lambda:InvokeFunctionUrl"
+  function_name = module.lambda_admin.function_name
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.admin.arn
 }
 
 # S3 Bucket Policy - Allow CloudFront access via OAC

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -54,11 +54,12 @@ module "api_gateway" {
 module "lambda_admin" {
   source = "../../modules/lambda"
 
-  function_name = "${local.project}-admin-api-${local.environment}"
-  image_uri     = "579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-admin-api:dev"
-  architectures = ["arm64"]
-  timeout       = 30
-  memory_size   = 512
+  function_name          = "${local.project}-admin-api-${local.environment}"
+  function_url_auth_type = "AWS_IAM"
+  image_uri              = "579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-admin-api:dev"
+  architectures          = ["arm64"]
+  timeout                = 30
+  memory_size            = 512
 
   environment_variables = {
     DATABASE_URL                     = neon_project.default.connection_uri

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -91,7 +91,7 @@ resource "aws_lambda_function" "this" {
 resource "aws_lambda_function_url" "this" {
   count              = var.create_function_url ? 1 : 0
   function_name      = aws_lambda_function.this.function_name
-  authorization_type = "NONE"
+  authorization_type = var.function_url_auth_type
 
   cors {
     allow_credentials = false

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -44,6 +44,12 @@ variable "create_function_url" {
   default     = true
 }
 
+variable "function_url_auth_type" {
+  description = "Authorization type for Lambda Function URL (NONE or AWS_IAM)"
+  type        = string
+  default     = "NONE"
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)


### PR DESCRIPTION
## Summary

- 管理APIのLambda Function URLに CloudFront OAC (Origin Access Control) for Lambda を追加
- `authorization_type` を `NONE` → `AWS_IAM` に変更し、直アクセスを拒否
- CloudFront経由のみアクセス可能に（SigV4署名で認証）

## アーキテクチャ変更

```
Before: CloudFront → Lambda Function URL (認証なし、直アクセス可能)
After:  CloudFront (OAC/SigV4署名) → Lambda Function URL (AWS_IAM)
```

## 検証結果

- 直アクセス (`curl Function URL`) → **403** (拒否)
- CloudFront経由 (`curl admin.dev.rikako.jp/api/health`) → **200** (正常)

## Test plan

- [x] `terraform apply` 成功
- [x] CloudFront経由のアクセスが正常動作
- [x] Lambda Function URL直アクセスが403で拒否される

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)