### PR TITLE
Fix admin dev smoke tests via CloudFront

### DIFF
--- a/.github/workflows/deploy-admin-dev.yml
+++ b/.github/workflows/deploy-admin-dev.yml
@@ -64,15 +64,18 @@ jobs:
             --function-name "$FUNCTION_NAME"
 
       - name: Smoke tests
+        env:
+          ADMIN_API_URL: https://admin.dev.rikako.jp/api
         run: |
-          FUNCTION_URL=$(aws lambda get-function-url-config --function-name rikako-admin-api-development --query 'FunctionUrl' --output text)
-          echo "Function URL: $FUNCTION_URL"
+          ADMIN_BASIC_AUTH_USER=$(aws ssm get-parameter --name /rikako/admin-basic-auth-user --query 'Parameter.Value' --output text)
+          ADMIN_BASIC_AUTH_PASSWORD=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-password --query 'Parameter.Value' --output text)
+          AUTH_HEADER="Authorization: Basic $(printf '%s' "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" | base64)"
           FAILED=0
 
           check_endpoint() {
             local name="$1"
             local url="$2"
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "$AUTH_HEADER" "$url")
             if [ "$STATUS" = "200" ]; then
               echo "✅ $name (HTTP $STATUS)"
             else
@@ -82,9 +85,9 @@ jobs:
           }
 
           echo "Running smoke tests..."
-          check_endpoint "Admin API /health" "${FUNCTION_URL}health"
-          check_endpoint "Admin API /categories" "${FUNCTION_URL}categories"
-          check_endpoint "Admin API /workbooks" "${FUNCTION_URL}workbooks"
+          check_endpoint "Admin API /health" "${ADMIN_API_URL}/health"
+          check_endpoint "Admin API /categories" "${ADMIN_API_URL}/categories"
+          check_endpoint "Admin API /workbooks" "${ADMIN_API_URL}/workbooks"
 
           if [ "$FAILED" -eq 1 ]; then
             echo "::error::Smoke tests failed"


### PR DESCRIPTION
## Summary
- switch Deploy Admin API Dev smoke tests from direct Function URL access to CloudFront via `https://admin.dev.rikako.jp/api`
- fetch admin basic auth credentials from SSM in the workflow and send the `Authorization` header
- keep the existing `/health`, `/categories`, `/workbooks` checks, but validate the real public admin path

## Test plan
- [ ] merge this PR
- [ ] confirm `Deploy Admin API Dev` passes on `main`

Closes #112