### PR TITLE
Deploy Admin API Dev の smoke test を CloudFront Basic 認証対応に修正

### DIFF
--- a/.github/workflows/deploy-admin-dev.yml
+++ b/.github/workflows/deploy-admin-dev.yml
@@ -64,17 +64,19 @@ jobs:
             --function-name "$FUNCTION_NAME"
 
       - name: Smoke tests
+        env:
+          ADMIN_API_URL: https://admin.dev.rikako.jp/api
         run: |
-          FUNCTION_URL=$(aws lambda get-function-url-config --function-name rikako-admin-api-development --query 'FunctionUrl' --output text)
+          ADMIN_BASIC_AUTH_USER=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-user --query 'Parameter.Value' --output text)
+          ADMIN_BASIC_AUTH_PASSWORD=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-password --query 'Parameter.Value' --output text)
           FAILED=0
 
           check_endpoint() {
             local name="$1"
             local url="$2"
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              --aws-sigv4 "aws:amz:${AWS_REGION}:lambda" \
-              --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" \
-              -H "x-amz-security-token: ${AWS_SESSION_TOKEN}" \
+              -L \
+              -u "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" \
               "$url")
             if [ "$STATUS" = "200" ]; then
               echo "✅ $name (HTTP $STATUS)"
@@ -85,9 +87,9 @@ jobs:
           }
 
           echo "Running smoke tests..."
-          check_endpoint "Admin API /health" "${FUNCTION_URL}health"
-          check_endpoint "Admin API /categories" "${FUNCTION_URL}categories"
-          check_endpoint "Admin API /workbooks" "${FUNCTION_URL}workbooks"
+          check_endpoint "Admin API /health" "${ADMIN_API_URL}/health"
+          check_endpoint "Admin API /categories" "${ADMIN_API_URL}/categories"
+          check_endpoint "Admin API /workbooks" "${ADMIN_API_URL}/workbooks"
 
           if [ "$FAILED" -eq 1 ]; then
             echo "::error::Smoke tests failed"

--- a/.github/workflows/deploy-admin-dev.yml
+++ b/.github/workflows/deploy-admin-dev.yml
@@ -64,17 +64,18 @@ jobs:
             --function-name "$FUNCTION_NAME"
 
       - name: Smoke tests
-        env:
-          ADMIN_API_URL: https://admin.dev.rikako.jp/api
         run: |
-          ADMIN_BASIC_AUTH_USER=$(aws ssm get-parameter --name /rikako/admin-basic-auth-user --query 'Parameter.Value' --output text)
-          ADMIN_BASIC_AUTH_PASSWORD=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-password --query 'Parameter.Value' --output text)
+          FUNCTION_URL=$(aws lambda get-function-url-config --function-name rikako-admin-api-development --query 'FunctionUrl' --output text)
           FAILED=0
 
           check_endpoint() {
             local name="$1"
             local url="$2"
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" "$url")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --aws-sigv4 "aws:amz:${AWS_REGION}:lambda" \
+              --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" \
+              -H "x-amz-security-token: ${AWS_SESSION_TOKEN}" \
+              "$url")
             if [ "$STATUS" = "200" ]; then
               echo "✅ $name (HTTP $STATUS)"
             else
@@ -84,9 +85,9 @@ jobs:
           }
 
           echo "Running smoke tests..."
-          check_endpoint "Admin API /health" "${ADMIN_API_URL}/health"
-          check_endpoint "Admin API /categories" "${ADMIN_API_URL}/categories"
-          check_endpoint "Admin API /workbooks" "${ADMIN_API_URL}/workbooks"
+          check_endpoint "Admin API /health" "${FUNCTION_URL}health"
+          check_endpoint "Admin API /categories" "${FUNCTION_URL}categories"
+          check_endpoint "Admin API /workbooks" "${FUNCTION_URL}workbooks"
 
           if [ "$FAILED" -eq 1 ]; then
             echo "::error::Smoke tests failed"

--- a/.github/workflows/deploy-admin-dev.yml
+++ b/.github/workflows/deploy-admin-dev.yml
@@ -69,13 +69,12 @@ jobs:
         run: |
           ADMIN_BASIC_AUTH_USER=$(aws ssm get-parameter --name /rikako/admin-basic-auth-user --query 'Parameter.Value' --output text)
           ADMIN_BASIC_AUTH_PASSWORD=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-password --query 'Parameter.Value' --output text)
-          AUTH_HEADER="Authorization: Basic $(printf '%s' "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" | base64 | tr -d '\n')"
           FAILED=0
 
           check_endpoint() {
             local name="$1"
             local url="$2"
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "$AUTH_HEADER" "$url")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" "$url")
             if [ "$STATUS" = "200" ]; then
               echo "✅ $name (HTTP $STATUS)"
             else

--- a/.github/workflows/deploy-admin-dev.yml
+++ b/.github/workflows/deploy-admin-dev.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           ADMIN_BASIC_AUTH_USER=$(aws ssm get-parameter --name /rikako/admin-basic-auth-user --query 'Parameter.Value' --output text)
           ADMIN_BASIC_AUTH_PASSWORD=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-password --query 'Parameter.Value' --output text)
-          AUTH_HEADER="Authorization: Basic $(printf '%s' "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" | base64)"
+          AUTH_HEADER="Authorization: Basic $(printf '%s' "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" | base64 | tr -d '\n')"
           FAILED=0
 
           check_endpoint() {


### PR DESCRIPTION
## Summary
- Admin API の smoke test は CloudFront 経由の `https://admin.dev.rikako.jp/api` を引き続き利用
- Basic 認証のユーザー名・パスワードの両方を `--with-decryption` で取得するよう修正
- PR 作成前にこのブランチで `Deploy Admin API Dev` を `workflow_dispatch` 実行し、成功を確認

## Verification
- [x] ブランチ `fix/admin-dev-basic-auth-header` で `Deploy Admin API Dev` の `workflow_dispatch` が成功
- [ ] この PR をマージする
- [ ] `main` への push で起動する `Deploy Admin API Dev` も成功することを確認

Closes #112