### PR TITLE
管理APIの GET /workbooks/{id} を一括取得に置き換えてタイムアウトを解消する

### DIFF
--- a/app/internal/admin/handler.go
+++ b/app/internal/admin/handler.go
@@ -602,18 +602,66 @@ func (h *Handler) getWorkbookDetail(ctx context.Context, workbookID int64) (*adm
 		return nil, err
 	}
 
-	qRows, err := h.queries.ListQuestionsByWorkbook(ctx, wb.ID)
+	rows, err := h.queries.ListQuestionsWithChoicesByWorkbook(ctx, wb.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	questions := []adminapi.Question{}
-	for _, row := range qRows {
-		q, err := h.getQuestionByID(ctx, row.ID)
+	type questionData struct {
+		question adminapi.Question
+	}
+
+	questionsMap := map[int64]*questionData{}
+	questionOrder := make([]int64, 0)
+
+	for _, row := range rows {
+		qd, exists := questionsMap[row.ID]
+		if !exists {
+			q := adminapi.Question{
+				Id:   row.ID,
+				Type: adminapi.QuestionTypeSingleChoice,
+				Text: row.Text,
+			}
+			if row.Explanation.Valid {
+				q.Explanation = &row.Explanation.String
+			}
+			qd = &questionData{question: q}
+			questionsMap[row.ID] = qd
+			questionOrder = append(questionOrder, row.ID)
+		}
+
+		if row.ChoiceText.Valid {
+			qd.question.Choices = append(qd.question.Choices, adminapi.Choice{
+				Text:      row.ChoiceText.String,
+				IsCorrect: row.IsCorrect.Valid && row.IsCorrect.Bool,
+			})
+		}
+	}
+
+	if len(questionOrder) > 0 {
+		imageRows, err := h.queries.GetImageURLsByQuestionIDs(ctx, questionOrder)
 		if err != nil {
 			return nil, err
 		}
-		questions = append(questions, *q)
+
+		for _, imageRow := range imageRows {
+			if qd, ok := questionsMap[imageRow.QuestionID]; ok {
+				url := fmt.Sprintf("%s/%s", h.imageBaseURL, imageRow.Path)
+				if qd.question.Images == nil {
+					urls := []string{url}
+					qd.question.Images = &urls
+				} else {
+					*qd.question.Images = append(*qd.question.Images, url)
+				}
+			}
+		}
+	}
+
+	questions := make([]adminapi.Question, 0, len(questionOrder))
+	for _, questionID := range questionOrder {
+		if qd, ok := questionsMap[questionID]; ok {
+			questions = append(questions, qd.question)
+		}
 	}
 
 	w := &adminapi.WorkbookDetail{

--- a/app/internal/admin/handler_test.go
+++ b/app/internal/admin/handler_test.go
@@ -270,6 +270,61 @@ func TestCreateAndGetWorkbook(t *testing.T) {
 	testDB.ExecContext(ctx, `DELETE FROM workbooks WHERE id = $1`, created.Id)
 }
 
+func TestGetWorkbook_IncludesQuestionsAndChoices(t *testing.T) {
+	h := newTestHandler()
+	ctx := context.Background()
+
+	questionResp, err := h.CreateQuestion(ctx, adminapi.CreateQuestionRequestObject{
+		Body: &adminapi.CreateQuestionRequest{
+			Type: adminapi.CreateQuestionRequestTypeSingleChoice,
+			Text: "workbook question",
+			Choices: []adminapi.Choice{
+				{Text: "A", IsCorrect: false},
+				{Text: "B", IsCorrect: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating question: %v", err)
+	}
+	createdQuestion := questionResp.(adminapi.CreateQuestion201JSONResponse)
+
+	workbookResp, err := h.CreateWorkbook(ctx, adminapi.CreateWorkbookRequestObject{
+		Body: &adminapi.CreateWorkbookRequest{
+			Title:       "detail workbook",
+			QuestionIds: &[]int64{createdQuestion.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating workbook: %v", err)
+	}
+	createdWorkbook := workbookResp.(adminapi.CreateWorkbook201JSONResponse)
+
+	getResp, err := h.GetWorkbook(ctx, adminapi.GetWorkbookRequestObject{WorkbookId: createdWorkbook.Id})
+	if err != nil {
+		t.Fatalf("unexpected error getting workbook: %v", err)
+	}
+	got, ok := getResp.(adminapi.GetWorkbook200JSONResponse)
+	if !ok {
+		t.Fatalf("expected GetWorkbook200JSONResponse, got %T", getResp)
+	}
+	if len(got.Questions) != 1 {
+		t.Fatalf("expected 1 question, got %d", len(got.Questions))
+	}
+	if got.Questions[0].Text != "workbook question" {
+		t.Fatalf("expected question text to match, got %q", got.Questions[0].Text)
+	}
+	if len(got.Questions[0].Choices) != 2 {
+		t.Fatalf("expected 2 choices, got %d", len(got.Questions[0].Choices))
+	}
+	if !got.Questions[0].Choices[1].IsCorrect {
+		t.Fatal("expected second choice to be correct")
+	}
+
+	testDB.ExecContext(ctx, `DELETE FROM workbooks WHERE id = $1`, createdWorkbook.Id)
+	testDB.ExecContext(ctx, `DELETE FROM questions WHERE id = $1`, createdQuestion.Id)
+}
+
 func TestUpdateWorkbook(t *testing.T) {
 	h := newTestHandler()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- 管理APIの `getWorkbookDetail` を N+1 取得から一括取得クエリベースに置き換え
- `ListQuestionsWithChoicesByWorkbook` と `GetImageURLsByQuestionIDs` を使って問題・選択肢・画像をまとめて構築
- workbook detail に問題と選択肢が含まれることを確認するテストを追加

## Verification
- [x] `go build ./internal/admin`
- [ ] `go test ./internal/admin/...` はローカル Postgres 未起動のため未実行
- [ ] PR 上で CI / 動作確認

Closes #115