### PR TITLE
管理画面の問題集詳細で問題の解説を表示する

### DIFF
--- a/admin/src/components/workbooks/workbook-detail.tsx
+++ b/admin/src/components/workbooks/workbook-detail.tsx
@@ -116,14 +116,26 @@ export function WorkbookDetail({ id }: { id: number }) {
                     <TableRow key={q.id}>
                       <TableCell>{q.id}</TableCell>
                       <TableCell>
-                        <Link
-                          href={`/questions/${q.id}`}
-                          className="hover:underline"
-                        >
-                          {q.text.length > 60
-                            ? `${q.text.slice(0, 60)}...`
-                            : q.text}
-                        </Link>
+                        <div className="space-y-2">
+                          <Link
+                            href={`/questions/${q.id}`}
+                            className="hover:underline"
+                          >
+                            {q.text.length > 60
+                              ? `${q.text.slice(0, 60)}...`
+                              : q.text}
+                          </Link>
+                          {q.explanation && (
+                            <div className="rounded-md bg-muted/50 p-3">
+                              <p className="text-xs font-medium text-muted-foreground">
+                                解説
+                              </p>
+                              <p className="mt-1 whitespace-pre-wrap text-sm">
+                                {q.explanation}
+                              </p>
+                            </div>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell>
                         <Badge variant="secondary">


### PR DESCRIPTION
## Summary
- 問題集詳細ページで、各問題に紐づく解説をそのまま表示
- 解説は問題文の直下に表示し、複数行でも読めるよう `whitespace-pre-wrap` で整形
- 解説がない問題では表示しない

## Verification
- [x] `cd admin && npm run build`
- [ ] PR 上で見た目確認

Closes #117