### PR TITLE
問題集詳細ページでは解説を表示しないように戻す

### DIFF
--- a/admin/src/components/workbooks/workbook-detail.tsx
+++ b/admin/src/components/workbooks/workbook-detail.tsx
@@ -116,26 +116,14 @@ export function WorkbookDetail({ id }: { id: number }) {
                     <TableRow key={q.id}>
                       <TableCell>{q.id}</TableCell>
                       <TableCell>
-                        <div className="space-y-2">
-                          <Link
-                            href={`/questions/${q.id}`}
-                            className="hover:underline"
-                          >
-                            {q.text.length > 60
-                              ? `${q.text.slice(0, 60)}...`
-                              : q.text}
-                          </Link>
-                          {q.explanation && (
-                            <div className="rounded-md bg-muted/50 p-3">
-                              <p className="text-xs font-medium text-muted-foreground">
-                                解説
-                              </p>
-                              <p className="mt-1 whitespace-pre-wrap text-sm">
-                                {q.explanation}
-                              </p>
-                            </div>
-                          )}
-                        </div>
+                        <Link
+                          href={`/questions/${q.id}`}
+                          className="hover:underline"
+                        >
+                          {q.text.length > 60
+                            ? `${q.text.slice(0, 60)}...`
+                            : q.text}
+                        </Link>
                       </TableCell>
                       <TableCell>
                         <Badge variant="secondary">


### PR DESCRIPTION
## Summary
- 問題集詳細ページで各問題の解説を表示していた変更を戻す
- 問題文から問題詳細ページへ遷移して、解説はそちらで確認する前提に戻す

## Verification
- [x] `cd admin && npm run build`
- [ ] PR 上で見た目確認
