### PR TITLE
管理APIの GET /questions を一括取得に置き換えて一覧表示を高速化する

### DIFF
--- a/app/internal/admin/handler.go
+++ b/app/internal/admin/handler.go
@@ -295,7 +295,7 @@ func (h *Handler) GetQuestions(ctx context.Context, request adminapi.GetQuestion
 		return nil, err
 	}
 
-	rows, err := h.queries.ListQuestions(ctx, db.ListQuestionsParams{
+	rows, err := h.queries.ListQuestionsWithChoices(ctx, db.ListQuestionsWithChoicesParams{
 		Limit:  int32(limit),
 		Offset: int32(offset),
 	})
@@ -304,14 +304,62 @@ func (h *Handler) GetQuestions(ctx context.Context, request adminapi.GetQuestion
 		return nil, err
 	}
 
-	questions := []adminapi.Question{}
+	type questionData struct {
+		question adminapi.Question
+	}
+
+	questionsMap := map[int64]*questionData{}
+	questionOrder := make([]int64, 0)
+
 	for _, row := range rows {
-		q, err := h.getQuestionByID(ctx, row.ID)
+		qd, exists := questionsMap[row.ID]
+		if !exists {
+			q := adminapi.Question{
+				Id:   row.ID,
+				Type: adminapi.QuestionTypeSingleChoice,
+				Text: row.Text,
+			}
+			if row.Explanation.Valid {
+				q.Explanation = &row.Explanation.String
+			}
+			qd = &questionData{question: q}
+			questionsMap[row.ID] = qd
+			questionOrder = append(questionOrder, row.ID)
+		}
+
+		if row.ChoiceText.Valid {
+			qd.question.Choices = append(qd.question.Choices, adminapi.Choice{
+				Text:      row.ChoiceText.String,
+				IsCorrect: row.IsCorrect.Valid && row.IsCorrect.Bool,
+			})
+		}
+	}
+
+	if len(questionOrder) > 0 {
+		imageRows, err := h.queries.GetImageURLsByQuestionIDs(ctx, questionOrder)
 		if err != nil {
-			h.logger.Error("failed to get question", "error", err, "question_id", row.ID)
+			h.logger.Error("failed to get question images", "error", err)
 			return nil, err
 		}
-		questions = append(questions, *q)
+
+		for _, imageRow := range imageRows {
+			if qd, ok := questionsMap[imageRow.QuestionID]; ok {
+				url := fmt.Sprintf("%s/%s", h.imageBaseURL, imageRow.Path)
+				if qd.question.Images == nil {
+					urls := []string{url}
+					qd.question.Images = &urls
+				} else {
+					*qd.question.Images = append(*qd.question.Images, url)
+				}
+			}
+		}
+	}
+
+	questions := make([]adminapi.Question, 0, len(questionOrder))
+	for _, questionID := range questionOrder {
+		if qd, ok := questionsMap[questionID]; ok {
+			questions = append(questions, qd.question)
+		}
 	}
 
 	return adminapi.GetQuestions200JSONResponse{Questions: questions, Total: int(total)}, nil

--- a/app/internal/admin/handler_test.go
+++ b/app/internal/admin/handler_test.go
@@ -491,3 +491,57 @@ func TestGetQuestions_Pagination(t *testing.T) {
 		}
 	})
 }
+
+func TestGetQuestions_IncludesChoices(t *testing.T) {
+	h := newTestHandler()
+	ctx := context.Background()
+
+	beforeResp, err := h.GetQuestions(ctx, adminapi.GetQuestionsRequestObject{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	before := beforeResp.(adminapi.GetQuestions200JSONResponse)
+
+	createResp, err := h.CreateQuestion(ctx, adminapi.CreateQuestionRequestObject{
+		Body: &adminapi.CreateQuestionRequest{
+			Type: adminapi.CreateQuestionRequestTypeSingleChoice,
+			Text: "list question",
+			Choices: []adminapi.Choice{
+				{Text: "A", IsCorrect: false},
+				{Text: "B", IsCorrect: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	created := createResp.(adminapi.CreateQuestion201JSONResponse)
+
+	limit := 1
+	offset := before.Total
+	resp, err := h.GetQuestions(ctx, adminapi.GetQuestionsRequestObject{
+		Params: adminapi.GetQuestionsParams{Limit: &limit, Offset: &offset},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, ok := resp.(adminapi.GetQuestions200JSONResponse)
+	if !ok {
+		t.Fatalf("expected GetQuestions200JSONResponse, got %T", resp)
+	}
+	if len(got.Questions) == 0 {
+		t.Fatal("expected at least one question")
+	}
+	target := got.Questions[0]
+	if target.Id != created.Id {
+		t.Fatalf("expected created question %d, got %d", created.Id, target.Id)
+	}
+	if len(target.Choices) != 2 {
+		t.Fatalf("expected 2 choices, got %d", len(target.Choices))
+	}
+	if !target.Choices[1].IsCorrect {
+		t.Fatal("expected second choice to be correct")
+	}
+
+	testDB.ExecContext(ctx, `DELETE FROM questions WHERE id = $1`, created.Id)
+}


### PR DESCRIPTION
## Summary
- 管理APIの `GetQuestions` を N+1 取得から一括取得クエリベースに置き換え
- `ListQuestionsWithChoices` と `GetImageURLsByQuestionIDs` を使って問題・選択肢・画像をまとめて構築
- questions list レスポンスに choices が含まれることを確認するテストを追加

## Verification
- [x] `go build ./internal/admin`
- [ ] `go test ./internal/admin/...` はローカル Postgres 未起動のため未実行
- [ ] branch deploy で `/questions/` の表示速度を確認

Closes #120