### PR TITLE
docs workflow の Node 24 警告対応

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run migrations
         run: |
@@ -56,7 +56,7 @@ jobs:
         run: cp openapi.yaml docs/api/
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -67,7 +67,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
 
@@ -80,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 概要
- docs workflow で直接指定している action を Node 24 対応版へ更新しました
- docs workflow 全体で JavaScript action を Node 24 実行へ寄せました
- branch 上で `Deploy Docs` を実行し、build が通ることを確認しました

## 変更内容
- `.github/workflows/docs.yml` で以下を更新
  - `actions/checkout@v4` -> `actions/checkout@v5`
  - `actions/setup-python@v5` -> `actions/setup-python@v6`
  - `actions/upload-pages-artifact@v3` -> `actions/upload-pages-artifact@v4`
  - `actions/deploy-pages@v4` -> `actions/deploy-pages@v5`
- workflow 環境変数として `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を追加

## 補足
- branch での `deploy` 失敗は `github-pages` 環境保護のためで、今回の修正とは無関係です
- 残る annotation は `actions/upload-pages-artifact` の内部で使われている `actions/upload-artifact` 由来です
- こちらが直接 `uses:` している action は Node 24 対応版へ上げ切っています
- 現時点では workflow 側で `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` を入れるのが現実的な対応です

## 確認
- `gh workflow run docs.yml --ref fix/docs-node24-actions`
- `gh run view 24302477810`
