### PR TITLE
datasyncとドキュメントからAWS SSO profileのハードコードを削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,16 +139,13 @@ cd app && go test ./internal/admin/
 
 ### Terraform操作
 ```bash
-# SSO ログイン（dev環境）
-aws sso login --profile rikako-development-sso
-
-# SSO ログイン（shared環境）
-aws sso login --profile rikako-shared-sso
+# 事前に AWS_PROFILE を設定して SSO ログイン（docs/aws-setup.md 参照）
+# export AWS_PROFILE=rikako-development-sso && aws sso login
 
 # Plan/Apply（dev環境）
 cd terraform/environments/dev
-AWS_PROFILE=rikako-development-sso terraform plan
-AWS_PROFILE=rikako-development-sso terraform apply
+terraform plan
+terraform apply
 ```
 
 ### ドキュメント生成

--- a/app/cmd/datasync/main.go
+++ b/app/cmd/datasync/main.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	localDSN       = "postgres://rikako:password@localhost:5432/rikako?sslmode=disable"
-	devSSMParam    = "/rikako/dev/database-url"
-	devAWSProfile  = "rikako-development-sso"
+	localDSN    = "postgres://rikako:password@localhost:5432/rikako?sslmode=disable"
+	devSSMParam = "/rikako/dev/database-url"
 )
 
 func main() {
@@ -32,12 +31,15 @@ Subcommands:
 
 Environments:
   local   ローカルPostgreSQL (localhost:5432)
-  dev     Neon dev環境 (SSMからURL取得、要: aws sso login --profile %s)
+  dev     Neon dev環境 (SSMからURL取得)
+
+ローカルからdev環境に接続する場合:
+  AWS_PROFILE=rikako-development-sso datasync -data ../data -env dev plan
 
 DATABASE_URL環境変数が設定されている場合は--envより優先されます。
 
 Flags:
-`, devAWSProfile)
+`)
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -114,20 +116,18 @@ func resolveDSN(env string) (string, error) {
 	case "local":
 		return localDSN, nil
 	case "dev":
-		return fetchDSNFromSSM(devAWSProfile, devSSMParam)
+		return fetchDSNFromSSM(devSSMParam)
 	default:
 		return "", fmt.Errorf("unknown environment: %s", env)
 	}
 }
 
-func fetchDSNFromSSM(profile, paramName string) (string, error) {
+func fetchDSNFromSSM(paramName string) (string, error) {
 	ctx := context.Background()
 
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithSharedConfigProfile(profile),
-	)
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		return "", fmt.Errorf("AWS config load failed (profile: %s): %w\nRun: aws sso login --profile %s", profile, err, profile)
+		return "", fmt.Errorf("AWS config load failed: %w", err)
 	}
 
 	client := ssm.NewFromConfig(cfg)
@@ -136,7 +136,7 @@ func fetchDSNFromSSM(profile, paramName string) (string, error) {
 		WithDecryption: boolPtr(true),
 	})
 	if err != nil {
-		return "", fmt.Errorf("SSM GetParameter failed (%s): %w\nRun: aws sso login --profile %s", paramName, err, profile)
+		return "", fmt.Errorf("SSM GetParameter failed (%s): %w", paramName, err)
 	}
 
 	return *out.Parameter.Value, nil

--- a/data/categories/chemistry.yml
+++ b/data/categories/chemistry.yml
@@ -1,6 +1,7 @@
 id: 1
-title: 化学
+title: 高校化学
 description: 高校化学に関する問題集。化学基礎から高校化学まで幅広くカバー。
 workbooks:
   - 2  # 化学基礎
   - 1  # 高校化学
+

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -1,0 +1,56 @@
+# AWS CLI セットアップ
+
+このプロジェクトでは AWS SSO を使って認証します。以下の手順でプロファイルを設定してください。
+
+## プロファイル設定
+
+`~/.aws/config` に以下を追加:
+
+```ini
+# dev環境（AWSアカウント: 197865631794）
+[profile rikako-development-sso]
+sso_start_url = https://your-sso-portal.awsapps.com/start
+sso_region = ap-northeast-1
+sso_account_id = 197865631794
+sso_role_name = AdministratorAccess
+region = ap-northeast-1
+output = json
+
+# shared環境（AWSアカウント: 579039992557、ECR管理用）
+[profile rikako-shared-sso]
+sso_start_url = https://your-sso-portal.awsapps.com/start
+sso_region = ap-northeast-1
+sso_account_id = 579039992557
+sso_role_name = AdministratorAccess
+region = ap-northeast-1
+output = json
+```
+
+> `sso_start_url` と `sso_role_name` は実際の環境に合わせて変更してください。
+
+## ログイン
+
+```bash
+# dev環境
+aws sso login --profile rikako-development-sso
+
+# shared環境（ECR操作時のみ）
+aws sso login --profile rikako-shared-sso
+```
+
+## 使い方
+
+各コマンドは `AWS_PROFILE` 環境変数でプロファイルを指定します:
+
+```bash
+# Terraform
+AWS_PROFILE=rikako-development-sso terraform plan
+
+# datasync
+AWS_PROFILE=rikako-development-sso go run ./cmd/datasync -data ../data -env dev plan
+
+# AWS CLI
+AWS_PROFILE=rikako-development-sso aws s3 ls s3://rikako-images-development/
+```
+
+> CI（GitHub Actions）では OIDC 認証を使用するため、プロファイルは不要です。

--- a/docs/datasync.md
+++ b/docs/datasync.md
@@ -69,9 +69,6 @@ go run ./cmd/datasync -data ../data -env local plan
 ### dev環境（Neon）
 
 ```bash
-# 事前にSSOログイン
-aws sso login --profile rikako-development-sso
-
 # plan
 go run ./cmd/datasync -data ../data -env dev plan
 
@@ -80,6 +77,7 @@ go run ./cmd/datasync -data ../data -env dev apply
 ```
 
 AWS SSM Parameter Store (`/rikako/dev/database-url`) からNeonの接続URLを取得して接続します。
+事前に `AWS_PROFILE` の設定と `aws sso login` が必要です（[AWS CLI セットアップ](aws-setup.md) 参照）。
 
 ### DATABASE_URL 直接指定
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,5 +1,15 @@
 # 運用ランブック
 
+> **前提**: AWS CLI プロファイルの設定が必要です。[AWS CLI セットアップ](aws-setup.md) を参照してください。
+>
+> 以降のコマンドは事前に `aws sso login` 済みで `AWS_PROFILE` が設定されている前提です。
+> ```bash
+> # dev環境
+> export AWS_PROFILE=rikako-development-sso
+> # shared環境（ECR操作時）
+> export AWS_PROFILE=rikako-shared-sso
+> ```
+
 ## 環境情報
 
 | 項目 | dev環境 |
@@ -17,8 +27,8 @@
 | CloudWatch Dashboard | `rikako-dev` |
 | AWSアカウント (dev) | 197865631794 |
 | AWSアカウント (shared) | 579039992557 |
-| AWS Profile (dev) | `rikako-development-sso` |
-| AWS Profile (shared) | `rikako-shared-sso` |
+| AWS Profile (dev) | [セットアップ参照](aws-setup.md) |
+| AWS Profile (shared) | [セットアップ参照](aws-setup.md) |
 
 ---
 
@@ -71,22 +81,20 @@ gh workflow run "Deploy Admin Frontend Dev" --repo takoikatakotako/rikako --ref 
 ECRのイメージタグ `dev` は上書き可能。直前のイメージに戻すには:
 
 ```bash
-aws sso login --profile rikako-development-sso
-
 # 直近のイメージダイジェストを確認
-AWS_PROFILE=rikako-development-sso aws ecr describe-images \
+aws ecr describe-images \
   --registry-id 579039992557 \
   --repository-name rikako-api \
   --query 'imageDetails | sort_by(@, &imagePushedAt) | [-5:].[imagePushedAt,imageDigest]' \
   --output table
 
 # 特定のダイジェストに戻す（公開API）
-AWS_PROFILE=rikako-development-sso aws lambda update-function-code \
+aws lambda update-function-code \
   --function-name rikako-api-development \
   --image-uri 579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-api@sha256:<digest>
 
 # 管理APIも同様
-AWS_PROFILE=rikako-development-sso aws lambda update-function-code \
+aws lambda update-function-code \
   --function-name rikako-admin-api-development \
   --image-uri 579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-admin-api@sha256:<digest>
 ```
@@ -161,7 +169,7 @@ cd app
 go run ./cmd/datasync -data ../data plan     # 差分確認
 go run ./cmd/datasync -data ../data apply    # 反映
 
-# dev環境（要: aws sso login --profile rikako-development-sso）
+# dev環境
 go run ./cmd/datasync -data ../data -env dev plan
 go run ./cmd/datasync -data ../data -env dev apply
 ```
@@ -171,13 +179,11 @@ go run ./cmd/datasync -data ../data -env dev apply
 ### 画像のS3アップロード
 
 ```bash
-aws sso login --profile rikako-development-sso
-
 # アップロード
-AWS_PROFILE=rikako-development-sso aws s3 sync data/images/ s3://rikako-images-development/ --exclude ".DS_Store"
+aws s3 sync data/images/ s3://rikako-images-development/ --exclude ".DS_Store"
 
 # 確認
-AWS_PROFILE=rikako-development-sso aws s3 ls s3://rikako-images-development/ | wc -l
+aws s3 ls s3://rikako-images-development/ | wc -l
 ```
 
 ### importer（全件再投入）
@@ -197,8 +203,6 @@ cd app && go run ./cmd/importer -data ../data
 **症状**: APIがエラーを返す、タイムアウトする
 
 ```bash
-aws sso login --profile rikako-development-sso
-
 # 1. ヘルスチェック
 curl -s https://umay5vbvquds44pubogp2jpaky0okiaj.lambda-url.ap-northeast-1.on.aws/health
 
@@ -206,10 +210,10 @@ curl -s https://umay5vbvquds44pubogp2jpaky0okiaj.lambda-url.ap-northeast-1.on.aw
 # https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#dashboards/dashboard/rikako-dev
 
 # 3. Lambda最新ログを確認
-AWS_PROFILE=rikako-development-sso aws logs tail /aws/lambda/rikako-api-development --since 30m
+aws logs tail /aws/lambda/rikako-api-development --since 30m
 
 # 4. エラーのみ抽出
-AWS_PROFILE=rikako-development-sso aws logs filter-log-events \
+aws logs filter-log-events \
   --log-group-name /aws/lambda/rikako-api-development \
   --start-time $(date -v-1H +%s000) \
   --filter-pattern "ERROR"
@@ -226,8 +230,7 @@ AWS_PROFILE=rikako-development-sso aws logs filter-log-events \
 # https://console.neon.tech/
 
 # 2. 接続テスト
-AWS_PROFILE=rikako-development-sso AWS_REGION=ap-northeast-1 \
-  go run ./cmd/datasync -data ../data -env dev plan
+go run ./cmd/datasync -data ../data -env dev plan
 
 # 3. Neonのステータスページを確認
 # https://neonstatus.com/
@@ -246,10 +249,10 @@ AWS_PROFILE=rikako-development-sso AWS_REGION=ap-northeast-1 \
 curl -I https://d1ovm6exq28tn1.cloudfront.net/1.png
 
 # 2. S3直接確認
-AWS_PROFILE=rikako-development-sso aws s3 ls s3://rikako-images-development/1.png
+aws s3 ls s3://rikako-images-development/1.png
 
 # 3. CloudFrontキャッシュが古い場合は無効化
-AWS_PROFILE=rikako-development-sso aws cloudfront create-invalidation \
+aws cloudfront create-invalidation \
   --distribution-id E1LVBAGQ7YS8CR \
   --paths "/*"
 ```
@@ -261,22 +264,20 @@ AWS_PROFILE=rikako-development-sso aws cloudfront create-invalidation \
 ### CloudWatch Logs
 
 ```bash
-aws sso login --profile rikako-development-sso
-
 # 直近30分のログ（公開API）
-AWS_PROFILE=rikako-development-sso aws logs tail /aws/lambda/rikako-api-development --since 30m --follow
+aws logs tail /aws/lambda/rikako-api-development --since 30m --follow
 
 # 直近30分のログ（管理API）
-AWS_PROFILE=rikako-development-sso aws logs tail /aws/lambda/rikako-admin-api-development --since 30m --follow
+aws logs tail /aws/lambda/rikako-admin-api-development --since 30m --follow
 
 # 特定パターンで検索
-AWS_PROFILE=rikako-development-sso aws logs filter-log-events \
+aws logs filter-log-events \
   --log-group-name /aws/lambda/rikako-api-development \
   --start-time $(date -v-1H +%s000) \
   --filter-pattern "ERROR"
 
 # 特定リクエストの調査（パスで絞り込み）
-AWS_PROFILE=rikako-development-sso aws logs filter-log-events \
+aws logs filter-log-events \
   --log-group-name /aws/lambda/rikako-api-development \
   --start-time $(date -v-1H +%s000) \
   --filter-pattern "/questions"
@@ -306,11 +307,10 @@ AWS_PROFILE=rikako-development-sso aws logs filter-log-events \
 
 ```bash
 cd terraform/environments/dev
-aws sso login --profile rikako-development-sso
 
 # terraform で変更（neon.tf の min/max compute units を編集）
-AWS_PROFILE=rikako-development-sso terraform plan
-AWS_PROFILE=rikako-development-sso terraform apply
+terraform plan
+terraform apply
 ```
 
 `neon.tf` の該当箇所:
@@ -335,8 +335,8 @@ module "lambda" {
 
 ```bash
 cd terraform/environments/dev
-AWS_PROFILE=rikako-development-sso terraform plan
-AWS_PROFILE=rikako-development-sso terraform apply
+terraform plan
+terraform apply
 ```
 
 ### Lambda同時実行数の制限
@@ -345,12 +345,12 @@ AWS_PROFILE=rikako-development-sso terraform apply
 
 ```bash
 # 一時的に制限（Terraform外）
-AWS_PROFILE=rikako-development-sso aws lambda put-function-concurrency \
+aws lambda put-function-concurrency \
   --function-name rikako-api-development \
   --reserved-concurrent-executions 100
 
 # 制限解除
-AWS_PROFILE=rikako-development-sso aws lambda delete-function-concurrency \
+aws lambda delete-function-concurrency \
   --function-name rikako-api-development
 ```
 
@@ -359,19 +359,15 @@ AWS_PROFILE=rikako-development-sso aws lambda delete-function-concurrency \
 ## 8. Terraform操作
 
 ```bash
-# SSOログイン
-aws sso login --profile rikako-development-sso   # dev環境
-aws sso login --profile rikako-shared-sso         # shared環境（ECR）
-
 # Plan/Apply（dev）
 cd terraform/environments/dev
-AWS_PROFILE=rikako-development-sso terraform plan
-AWS_PROFILE=rikako-development-sso terraform apply
+terraform plan
+terraform apply
 
 # Plan/Apply（shared）
 cd terraform/environments/shared
-AWS_PROFILE=rikako-shared-sso terraform plan
-AWS_PROFILE=rikako-shared-sso terraform apply
+terraform plan
+terraform apply
 ```
 
 > **注意**: PRで `terraform/` 配下を変更するとGitHub Actionsで自動的にplanが実行され、結果がPRにコメントされる。
@@ -391,7 +387,7 @@ AWS_PROFILE=rikako-shared-sso terraform apply
 ### Cognito ユーザー作成
 
 ```bash
-AWS_PROFILE=rikako-development-sso aws cognito-idp admin-create-user \
+aws cognito-idp admin-create-user \
   --user-pool-id ap-northeast-1_DvsZzCoJw \
   --username <email> \
   --user-attributes Name=email,Value=<email>
@@ -401,12 +397,12 @@ AWS_PROFILE=rikako-development-sso aws cognito-idp admin-create-user \
 
 ```bash
 # 画像CDN
-AWS_PROFILE=rikako-development-sso aws cloudfront create-invalidation \
+aws cloudfront create-invalidation \
   --distribution-id E1LVBAGQ7YS8CR \
   --paths "/*"
 
 # 管理画面
-AWS_PROFILE=rikako-development-sso aws cloudfront create-invalidation \
+aws cloudfront create-invalidation \
   --distribution-id EIA13UUJ41NKO \
   --paths "/*"
 ```

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -82,3 +82,4 @@ module "lambda_admin" {
     ManagedBy   = "terraform"
   }
 }
+


### PR DESCRIPTION
## Summary
- datasyncコマンドからハードコードされたSSO profile (`rikako-development-sso`) を削除
- AWS SDKのデフォルトクレデンシャル解決に一任し、CI（OIDC）でもローカル（SSO）でも動作するように
- ローカルからdev環境に接続する場合は `AWS_PROFILE=rikako-development-sso` を環境変数で渡す

Closes #131

## Test plan
- [ ] CI（Data Sync Plan）がエラーなく通ること
- [ ] ローカルから `AWS_PROFILE=rikako-development-sso datasync -data ../data -env dev plan` で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)