### PR TITLE
iOS/バックエンド: 学習UIと回答ログの改善

### DIFF
--- a/ios/Rikako/AppState.swift
+++ b/ios/Rikako/AppState.swift
@@ -1,6 +1,15 @@
 import Foundation
 import Observation
 
+extension DateFormatter {
+    static let yyyyMMdd: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+}
+
 @Observable
 @MainActor
 final class AppState {
@@ -12,6 +21,12 @@ final class AppState {
     private enum DefaultsKey {
         static let hasCompletedOnboarding = "jp.conol.rikako.hasCompletedOnboarding"
         static let anonymousUserId = "jp.conol.rikako.anonymousUserId"
+        static let studyDates = "jp.conol.rikako.studyDates"
+        static let weeklyAnswered = "jp.conol.rikako.weeklyAnswered"
+        static let weeklyCorrect = "jp.conol.rikako.weeklyCorrect"
+        static let weeklyCompletedWorkbookIDs = "jp.conol.rikako.weeklyCompletedWorkbookIDs"
+        static let currentWeekKey = "jp.conol.rikako.currentWeekKey"
+        static let questionResults = "jp.conol.rikako.questionResults"
     }
 
     var hasCompletedOnboarding: Bool
@@ -24,6 +39,12 @@ final class AppState {
     private(set) var totalCorrect: Int
     private(set) var completedWorkbookIDs: Set<Int64>
     private(set) var wrongQuestions: [Question]
+    private(set) var studyDates: Set<String>
+    private(set) var weeklyAnswered: Int
+    private(set) var weeklyCorrect: Int
+    private(set) var weeklyCompletedWorkbookIDs: Set<Int64>
+    // 問題IDごとの最新の正解/不正解 [questionId(String): isCorrect]
+    private(set) var questionResults: [String: Bool]
     private let userDefaults: UserDefaults
 
     private init(userDefaults: UserDefaults = .standard) {
@@ -38,11 +59,40 @@ final class AppState {
         self.totalCorrect = 0
         self.completedWorkbookIDs = []
         self.wrongQuestions = []
+        self.studyDates = Set(userDefaults.stringArray(forKey: DefaultsKey.studyDates) ?? [])
+        self.questionResults = (userDefaults.dictionary(forKey: DefaultsKey.questionResults) as? [String: Bool]) ?? [:]
+
+        let savedWeek = userDefaults.string(forKey: DefaultsKey.currentWeekKey) ?? ""
+        let currentWeek = AppState.isoWeekKey(for: Date())
+        if savedWeek == currentWeek {
+            self.weeklyAnswered = userDefaults.integer(forKey: DefaultsKey.weeklyAnswered)
+            self.weeklyCorrect = userDefaults.integer(forKey: DefaultsKey.weeklyCorrect)
+            let ids = userDefaults.array(forKey: DefaultsKey.weeklyCompletedWorkbookIDs) as? [Int64] ?? []
+            self.weeklyCompletedWorkbookIDs = Set(ids)
+        } else {
+            self.weeklyAnswered = 0
+            self.weeklyCorrect = 0
+            self.weeklyCompletedWorkbookIDs = []
+        }
+    }
+
+    // "yyyy-Www" 形式（例: "2026-W17"）
+    private static func isoWeekKey(for date: Date) -> String {
+        let cal = Calendar(identifier: .iso8601)
+        let year = cal.component(.yearForWeekOfYear, from: date)
+        let week = cal.component(.weekOfYear, from: date)
+        return String(format: "%04d-W%02d", year, week)
     }
 
     var accuracyText: String {
         guard totalAnswered > 0 else { return "--%" }
         let percentage = Int((Double(totalCorrect) / Double(totalAnswered)) * 100)
+        return "\(percentage)%"
+    }
+
+    var weeklyAccuracyText: String {
+        guard weeklyAnswered > 0 else { return "--%" }
+        let percentage = Int((Double(weeklyCorrect) / Double(weeklyAnswered)) * 100)
         return "\(percentage)%"
     }
 
@@ -68,8 +118,19 @@ final class AppState {
         totalCorrect = 0
         completedWorkbookIDs = []
         wrongQuestions = []
+        studyDates = []
+        weeklyAnswered = 0
+        weeklyCorrect = 0
+        weeklyCompletedWorkbookIDs = []
         userDefaults.removeObject(forKey: DefaultsKey.hasCompletedOnboarding)
         userDefaults.removeObject(forKey: DefaultsKey.anonymousUserId)
+        userDefaults.removeObject(forKey: DefaultsKey.studyDates)
+        userDefaults.removeObject(forKey: DefaultsKey.weeklyAnswered)
+        userDefaults.removeObject(forKey: DefaultsKey.weeklyCorrect)
+        userDefaults.removeObject(forKey: DefaultsKey.weeklyCompletedWorkbookIDs)
+        userDefaults.removeObject(forKey: DefaultsKey.currentWeekKey)
+        questionResults = [:]
+        userDefaults.removeObject(forKey: DefaultsKey.questionResults)
     }
 
     func selectWorkbook(_ workbookID: Int64) {
@@ -92,6 +153,32 @@ final class AppState {
         totalAnswered += answeredCount
         totalCorrect += correctCount
         completedWorkbookIDs.insert(workbookId)
+
+        let today = DateFormatter.yyyyMMdd.string(from: Date())
+        studyDates.insert(today)
+        userDefaults.set(Array(studyDates), forKey: DefaultsKey.studyDates)
+
+        // 週が変わっていたらリセット
+        let currentWeek = AppState.isoWeekKey(for: Date())
+        if userDefaults.string(forKey: DefaultsKey.currentWeekKey) != currentWeek {
+            weeklyAnswered = 0
+            weeklyCorrect = 0
+            weeklyCompletedWorkbookIDs = []
+            userDefaults.set(currentWeek, forKey: DefaultsKey.currentWeekKey)
+        }
+
+        weeklyAnswered += answeredCount
+        weeklyCorrect += correctCount
+        weeklyCompletedWorkbookIDs.insert(workbookId)
+        userDefaults.set(weeklyAnswered, forKey: DefaultsKey.weeklyAnswered)
+        userDefaults.set(weeklyCorrect, forKey: DefaultsKey.weeklyCorrect)
+        userDefaults.set(Array(weeklyCompletedWorkbookIDs), forKey: DefaultsKey.weeklyCompletedWorkbookIDs)
+
+        // 問題ごとの正解/不正解を更新
+        for (question, answer) in answeredPairs {
+            questionResults[String(question.id)] = (answer == question.correctIndex)
+        }
+        userDefaults.set(questionResults, forKey: DefaultsKey.questionResults)
 
         var latestWrongQuestions = wrongQuestions
         for (question, answer) in answeredPairs {

--- a/ios/Rikako/Screen/Quiz/QuizView.swift
+++ b/ios/Rikako/Screen/Quiz/QuizView.swift
@@ -10,12 +10,17 @@ struct QuizView: View {
 
     private let choiceLabels = ["A", "B", "C", "D"]
 
-    init(questions: [Question], workbookTitle: String, workbookId: Int64) {
+    private let allSectionsQuestions: [[Question]]
+    private let currentSectionIndex: Int
+
+    init(questions: [Question], workbookTitle: String, workbookId: Int64, allSectionsQuestions: [[Question]] = [], currentSectionIndex: Int = 0) {
         _viewModel = State(initialValue: QuizViewModel(
             questions: questions,
             workbookTitle: workbookTitle,
             workbookId: workbookId
         ))
+        self.allSectionsQuestions = allSectionsQuestions
+        self.currentSectionIndex = currentSectionIndex
     }
 
     var body: some View {
@@ -88,6 +93,8 @@ struct QuizView: View {
                 answers: viewModel.answers,
                 workbookTitle: viewModel.workbookTitle,
                 workbookId: viewModel.workbookId,
+                allSectionsQuestions: allSectionsQuestions,
+                currentSectionIndex: currentSectionIndex,
                 onBackToWorkbookList: {
                     dismiss()
                 }
@@ -141,6 +148,8 @@ struct QuizView: View {
                     withAnimation {
                         viewModel.selectChoice(index)
                     }
+                    let feedback = UINotificationFeedbackGenerator()
+                    feedback.notificationOccurred(index == viewModel.currentQuestion.correctIndex ? .success : .error)
                 } label: {
                     HStack(spacing: 14) {
                         Text(choiceLabel(for: index))
@@ -156,17 +165,6 @@ struct QuizView: View {
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
-                        if viewModel.showExplanation {
-                            if index == viewModel.currentQuestion.correctIndex {
-                                Image(.questionCorrect)
-                                    .resizable()
-                                    .frame(width: 26, height: 26)
-                            } else if index == viewModel.selectedChoice {
-                                Image(.questionDiscorrect)
-                                    .resizable()
-                                    .frame(width: 26, height: 26)
-                            }
-                        }
                     }
                     .padding(18)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/Rikako/Screen/Result/ResultView.swift
+++ b/ios/Rikako/Screen/Result/ResultView.swift
@@ -4,6 +4,9 @@ struct ResultView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
     @State private var viewModel: ResultViewModel
+    @State private var showContinueQuiz = false
+    private let allSectionsQuestions: [[Question]]
+    private let currentSectionIndex: Int
     private let onBackToWorkbookList: () -> Void
 
     init(
@@ -11,6 +14,8 @@ struct ResultView: View {
         answers: [Int?],
         workbookTitle: String,
         workbookId: Int64,
+        allSectionsQuestions: [[Question]] = [],
+        currentSectionIndex: Int = 0,
         onBackToWorkbookList: @escaping () -> Void = {}
     ) {
         _viewModel = State(initialValue: ResultViewModel(
@@ -19,6 +24,8 @@ struct ResultView: View {
             workbookTitle: workbookTitle,
             workbookId: workbookId
         ))
+        self.allSectionsQuestions = allSectionsQuestions
+        self.currentSectionIndex = currentSectionIndex
         self.onBackToWorkbookList = onBackToWorkbookList
     }
 
@@ -27,6 +34,7 @@ struct ResultView: View {
             VStack(spacing: 24) {
                 scoreCard
                 questionResults
+                continueButton
                 backButton
             }
             .padding()
@@ -149,6 +157,33 @@ struct ResultView: View {
         .clipShape(RoundedRectangle(cornerRadius: 20))
     }
 
+    private var continueButton: some View {
+        let nextIndex = allSectionsQuestions.isEmpty ? 0 : (currentSectionIndex + 1) % allSectionsQuestions.count
+        let nextQuestions = allSectionsQuestions.isEmpty ? viewModel.questions : allSectionsQuestions[nextIndex]
+        let nextSectionNumber = nextIndex + 1
+
+        return Button {
+            showContinueQuiz = true
+        } label: {
+            Text(allSectionsQuestions.isEmpty ? "つづける" : "Section \(nextSectionNumber) へ")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color(.main))
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+        .navigationDestination(isPresented: $showContinueQuiz) {
+            QuizView(
+                questions: nextQuestions,
+                workbookTitle: viewModel.workbookTitle,
+                workbookId: viewModel.workbookId,
+                allSectionsQuestions: allSectionsQuestions,
+                currentSectionIndex: nextIndex
+            )
+        }
+    }
+
     private var backButton: some View {
         Button {
             dismiss()
@@ -160,8 +195,8 @@ struct ResultView: View {
                 .font(.headline)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color(.main))
-                .foregroundStyle(.white)
+                .background(Color(.systemGray5))
+                .foregroundStyle(.primary)
                 .clipShape(RoundedRectangle(cornerRadius: 16))
         }
     }

--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -182,7 +182,9 @@ struct StudyHomeView: View {
                 NavigationLink(destination: QuizView(
                     questions: viewModel.firstSectionQuestions(),
                     workbookTitle: workbookDetail.title,
-                    workbookId: workbookDetail.id
+                    workbookId: workbookDetail.id,
+                    allSectionsQuestions: viewModel.sections().map { viewModel.questions(for: $0) },
+                    currentSectionIndex: 0
                 )) {
                     VStack(spacing: 4) {
                         Text("はじめる")
@@ -234,7 +236,9 @@ struct StudyHomeView: View {
                 QuizView(
                     questions: questions,
                     workbookTitle: workbookDetail.title,
-                    workbookId: workbookDetail.id
+                    workbookId: workbookDetail.id,
+                    allSectionsQuestions: viewModel.sections().map { viewModel.questions(for: $0) },
+                    currentSectionIndex: section.id - 1
                 )
             }
         }) {

--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -44,7 +44,7 @@ struct StudyHomeView: View {
                                 workbookHero(selectedWorkbook)
                             }
 
-                            chapterPanel
+                            sectionPanel
                         }
                         .padding(.horizontal, 16)
                         .padding(.vertical, 12)
@@ -158,7 +158,7 @@ struct StudyHomeView: View {
         .frame(height: 230)
     }
 
-    private var chapterPanel: some View {
+    private var sectionPanel: some View {
         VStack(spacing: 0) {
             HStack {
                 Spacer()
@@ -180,14 +180,14 @@ struct StudyHomeView: View {
 
             if let workbookDetail = viewModel.workbookDetail {
                 NavigationLink(destination: QuizView(
-                    questions: viewModel.firstChapterQuestions(),
+                    questions: viewModel.firstSectionQuestions(),
                     workbookTitle: workbookDetail.title,
                     workbookId: workbookDetail.id
                 )) {
                     VStack(spacing: 4) {
                         Text("はじめる")
                             .font(.headline.bold())
-                        Text(viewModel.chapters().first?.title ?? "Lesson 1")
+                        Text(viewModel.sections().first?.title ?? "Section 1")
                             .font(.caption)
                     }
                     .foregroundStyle(.white)
@@ -209,9 +209,9 @@ struct StudyHomeView: View {
             }
 
             VStack(spacing: 0) {
-                ForEach(viewModel.chapters()) { chapter in
-                    chapterRow(chapter)
-                    if chapter.id != viewModel.chapters().last?.id {
+                ForEach(viewModel.sections()) { section in
+                    sectionRow(section)
+                    if section.id != viewModel.sections().last?.id {
                         Divider()
                             .padding(.leading, 54)
                     }
@@ -224,39 +224,62 @@ struct StudyHomeView: View {
         .clipShape(RoundedRectangle(cornerRadius: 24))
     }
 
-    private func chapterRow(_ chapter: StudyHomeViewModel.Chapter) -> some View {
-        HStack(spacing: 14) {
-            ZStack {
-                Circle()
-                    .stroke(Color.gray.opacity(0.35), lineWidth: 2)
-                    .frame(width: 38, height: 38)
+    private func sectionRow(_ section: StudyHomeViewModel.Section) -> some View {
+        let questions = viewModel.questions(for: section)
+        let workbookDetail = viewModel.workbookDetail
+        let progress = viewModel.sectionProgress(for: section, questionResults: appState.questionResults)
 
-                if chapter.isLocked {
-                    Image(systemName: "lock.fill")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(.gray)
-                } else {
-                    Text("\(chapter.id)")
+        return NavigationLink(destination: Group {
+            if let workbookDetail {
+                QuizView(
+                    questions: questions,
+                    workbookTitle: workbookDetail.title,
+                    workbookId: workbookDetail.id
+                )
+            }
+        }) {
+            HStack(spacing: 14) {
+                ZStack {
+                    Circle()
+                        .stroke(Color.gray.opacity(0.35), lineWidth: 2)
+                        .frame(width: 38, height: 38)
+                    Text("\(section.id)")
                         .font(.headline.bold())
                         .foregroundStyle(.primary)
                 }
+
+                Text(section.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                if progress.answered > 0 {
+                    HStack(spacing: 2) {
+                        Text("\(progress.correct)")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(Color(.main))
+                        Text("/\(section.questionCount)")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color(.systemGray6))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                } else {
+                    Text("\(section.questionCount)問")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color(.systemGray6))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
             }
-
-            Text(chapter.title)
-                .font(.headline)
-                .foregroundStyle(chapter.isLocked ? .secondary : .primary)
-
-            Spacer()
-
-            Text("\(chapter.questionCount)問")
-                .font(.subheadline.bold())
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(Color(.systemGray6))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.vertical, 14)
         }
-        .padding(.vertical, 14)
+        .buttonStyle(.plain)
     }
 
     private var skeletonView: some View {
@@ -267,7 +290,7 @@ struct StudyHomeView: View {
                     .fill(Color(.systemGray5))
                     .frame(height: 230)
 
-                // Chapter panel skeleton
+                // Section panel skeleton
                 VStack(spacing: 0) {
                     VStack(spacing: 8) {
                         skeletonRect(width: 120, height: 14)

--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -268,6 +268,7 @@ struct StudyHomeView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .padding(.vertical, 14)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -254,28 +254,18 @@ struct StudyHomeView: View {
 
                 Spacer()
 
-                if progress.answered > 0 {
-                    HStack(spacing: 2) {
-                        Text("\(progress.correct)")
-                            .font(.subheadline.bold())
-                            .foregroundStyle(Color(.main))
-                        Text("/\(section.questionCount)")
-                            .font(.subheadline.bold())
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(Color(.systemGray6))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                } else {
-                    Text("\(section.questionCount)問")
+                HStack(spacing: 2) {
+                    Text("\(progress.correct)")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(progress.answered > 0 ? Color(.main) : Color.secondary)
+                    Text("/\(section.questionCount)")
                         .font(.subheadline.bold())
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(Color(.systemGray6))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(.systemGray6))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .padding(.vertical, 14)
         }

--- a/ios/Rikako/Screen/StudyHome/StudyHomeViewModel.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeViewModel.swift
@@ -4,7 +4,7 @@ import Observation
 @Observable
 @MainActor
 final class StudyHomeViewModel {
-    struct Chapter: Identifiable {
+    struct Section: Identifiable {
         let id: Int
         let title: String
         let questionCount: Int
@@ -64,7 +64,7 @@ final class StudyHomeViewModel {
         }
     }
 
-    func chapters() -> [Chapter] {
+    func sections() -> [Section] {
         guard let workbookDetail else { return [] }
         let chunkSize = 10
         let total = workbookDetail.questions.count
@@ -72,27 +72,41 @@ final class StudyHomeViewModel {
         return (0..<chunkCount).map { index in
             let start = index * chunkSize
             let end = min(start + chunkSize, total)
-            return Chapter(
+            return Section(
                 id: index + 1,
-                title: "第\(index + 1)章 Lesson \(index + 1)",
+                title: "Section \(index + 1)",
                 questionCount: max(end - start, 0),
-                isLocked: index > 0
+                isLocked: false
             )
         }
     }
 
-    func questions(for chapter: Chapter) -> [Question] {
+    func questions(for section: Section) -> [Question] {
         guard let workbookDetail else { return [] }
         let chunkSize = 10
-        let start = max((chapter.id - 1) * chunkSize, 0)
+        let start = max((section.id - 1) * chunkSize, 0)
         let end = min(start + chunkSize, workbookDetail.questions.count)
         guard start < end else { return [] }
         return Array(workbookDetail.questions[start..<end])
     }
 
-    func firstChapterQuestions() -> [Question] {
-        guard let firstChapter = chapters().first else { return [] }
-        return questions(for: firstChapter)
+    // セクションの正解数と回答済み数を返す
+    func sectionProgress(for section: Section, questionResults: [String: Bool]) -> (correct: Int, answered: Int) {
+        let qs = questions(for: section)
+        var correct = 0
+        var answered = 0
+        for q in qs {
+            if let isCorrect = questionResults[String(q.id)] {
+                answered += 1
+                if isCorrect { correct += 1 }
+            }
+        }
+        return (correct, answered)
+    }
+
+    func firstSectionQuestions() -> [Question] {
+        guard let firstSection = sections().first else { return [] }
+        return questions(for: firstSection)
     }
 
     #if DEBUG

--- a/ios/Rikako/Screen/StudyRecord/StudyRecordView.swift
+++ b/ios/Rikako/Screen/StudyRecord/StudyRecordView.swift
@@ -8,7 +8,6 @@ struct StudyRecordView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    saleBanner
                     greetingSection
                     streakCard
                     reminderBanner
@@ -23,53 +22,17 @@ struct StudyRecordView: View {
         }
     }
 
-    private var saleBanner: some View {
-        RoundedRectangle(cornerRadius: 18)
-            .fill(
-                LinearGradient(
-                    colors: [Color.pink.opacity(0.22), Color.orange.opacity(0.20)],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
-            .frame(height: 76)
-            .overlay(
-                HStack(spacing: 14) {
-                    Image(.topAppLogo)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 48, height: 48)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("春のチャレンジ応援")
-                            .font(.headline.bold())
-                        Text("今日も10問ずつ進めていこう")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right.circle.fill")
-                        .foregroundStyle(Color(.main))
-                        .font(.title3)
-                }
-                .padding(.horizontal, 18)
-            )
-    }
-
     private var greetingSection: some View {
         HStack(alignment: .top, spacing: 12) {
-            Image(.topRikakoStanding)
-                .resizable()
-                .scaledToFit()
+            Image(systemName: "tortoise.fill")
+                .font(.title2)
+                .foregroundStyle(Color(.main))
                 .frame(width: 56, height: 56)
-                .padding(4)
                 .background(Color(.main).opacity(0.10))
                 .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("理科子さん、今日も勉強してえらいね！")
+                Text(appState.displayName.map { "\($0)さん、今日も勉強してえらいね！" } ?? "今日も勉強してえらいね！")
                     .font(.title3.bold())
                     .foregroundStyle(.primary)
 
@@ -82,18 +45,22 @@ struct StudyRecordView: View {
     }
 
     private var streakCard: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        let weekly = viewModel.weeklyStudied(studyDates: appState.studyDates)
+        let weeklyCount = viewModel.weeklyStudyCount(studyDates: appState.studyDates)
+        let streak = viewModel.streak(studyDates: appState.studyDates)
+
+        return VStack(alignment: .leading, spacing: 18) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("連続学習日数")
                         .font(.headline.bold())
-                    Text("自己ベスト: 2日")
+                    Text("今週の学習: \(weeklyCount)日")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
                 HStack(alignment: .lastTextBaseline, spacing: 2) {
-                    Text(viewModel.streakText(completedWorkbookIDs: appState.completedWorkbookIDs))
+                    Text("\(streak)")
                         .font(.system(size: 48, weight: .bold))
                         .foregroundStyle(Color(.main))
                     Text("日")
@@ -113,17 +80,14 @@ struct StudyRecordView: View {
                             .frame(width: 24, height: 24)
                             .background(
                                 Circle()
-                                    .fill(index < viewModel.activeDays(completedWorkbookIDs: appState.completedWorkbookIDs) ? Color(.main).opacity(0.18) : Color.clear)
+                                    .fill(weekly[index] ? Color(.main).opacity(0.18) : Color.clear)
                             )
                     }
                     .frame(maxWidth: .infinity)
                 }
             }
 
-            VStack(spacing: 12) {
-                chartRow(label: "学習時間", value: viewModel.chartValue(totalAnswered: appState.totalAnswered))
-                chartRow(label: "問題数", value: viewModel.chartValue(totalAnswered: appState.totalAnswered))
-            }
+            chartRow(label: "問題数", value: min(appState.totalAnswered, 30))
         }
         .padding(20)
         .background(
@@ -176,29 +140,19 @@ struct StudyRecordView: View {
 
     private var statsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("学習時間・日数")
-                    .font(.headline.bold())
-                Spacer()
-                Text("これまでの記録")
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color(.systemGray6))
-                    .clipShape(Capsule())
-            }
+            Text("今週の学習時間・日数")
+                .font(.headline.bold())
 
             HStack(spacing: 12) {
                 statTile(
                     title: "解答した問題",
-                    value: "\(appState.totalAnswered)問",
+                    value: "\(appState.weeklyAnswered)問",
                     icon: "square.and.pencil",
                     accentColor: Color(.main)
                 )
                 statTile(
                     title: "正答率",
-                    value: appState.accuracyText,
+                    value: appState.weeklyAccuracyText,
                     icon: "chart.line.uptrend.xyaxis",
                     accentColor: Color.green
                 )
@@ -207,7 +161,7 @@ struct StudyRecordView: View {
             HStack(spacing: 12) {
                 statTile(
                     title: "完了した問題集",
-                    value: "\(appState.completedWorkbookIDs.count)冊",
+                    value: "\(appState.weeklyCompletedWorkbookIDs.count)冊",
                     icon: "books.vertical.fill",
                     accentColor: Color.blue
                 )

--- a/ios/Rikako/Screen/StudyRecord/StudyRecordViewModel.swift
+++ b/ios/Rikako/Screen/StudyRecord/StudyRecordViewModel.swift
@@ -4,15 +4,51 @@ import Observation
 @Observable
 @MainActor
 final class StudyRecordViewModel {
-    func activeDays(completedWorkbookIDs: Set<Int64>) -> Int {
-        min(7, max(1, completedWorkbookIDs.count))
+    private let calendar = Calendar.current
+
+    // 連続学習日数（今日または昨日を含む連続した日数）
+    func streak(studyDates: Set<String>) -> Int {
+        guard !studyDates.isEmpty else { return 0 }
+
+        let formatter = DateFormatter.yyyyMMdd
+        var date = Date()
+        var count = 0
+
+        // 今日に記録がなければ昨日から遡る
+        if !studyDates.contains(formatter.string(from: date)) {
+            guard let yesterday = calendar.date(byAdding: .day, value: -1, to: date),
+                  studyDates.contains(formatter.string(from: yesterday)) else {
+                return 0
+            }
+            date = yesterday
+        }
+
+        while studyDates.contains(formatter.string(from: date)) {
+            count += 1
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: date) else { break }
+            date = prev
+        }
+        return count
     }
 
-    func streakText(completedWorkbookIDs: Set<Int64>) -> String {
-        "\(completedWorkbookIDs.count)"
+    // 今週（月〜日）の各曜日に学習したか（index 0=月 ... 6=日）
+    func weeklyStudied(studyDates: Set<String>) -> [Bool] {
+        let formatter = DateFormatter.yyyyMMdd
+        let today = Date()
+        // 今週の月曜日を取得
+        var components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)
+        components.weekday = 2  // 月曜
+        let monday = calendar.date(from: components) ?? today
+
+        return (0..<7).map { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: monday) else { return false }
+            return studyDates.contains(formatter.string(from: day))
+        }
     }
 
-    func chartValue(totalAnswered: Int) -> Int {
-        min(totalAnswered, 30)
+    // 今週の学習日数合計
+    func weeklyStudyCount(studyDates: Set<String>) -> Int {
+        weeklyStudied(studyDates: studyDates).filter { $0 }.count
     }
 }
+


### PR DESCRIPTION
## Summary

- ユーザー回答ログをDBに保存し、管理画面のユーザー詳細で確認できるように（`GET /users/{userId}/answers`、ページング対応）
- 結果画面から回答ログをサーバーに送信（`POST /answers`）
- StudyHomeView: セクション表示（Section 1, 2, ...）・全セクション開放・進捗表示（0/10形式）
- QuizView: 選択肢タップ時のハプティクス（正解:success/不正解:error）、○/×アイコン削除（色のみに）
- ResultView: 「つづける」ボタン追加（次セクションへ遷移、最後は先頭に戻る）
- StudyRecordView: 春バナー削除、ユーザー名表示、亀アイコン、実際の連続学習日数・週間統計

## Test plan

- [ ] 問題を解いて結果画面で「つづける」を押すと次のセクションへ遷移する
- [ ] 最後のセクション後に「つづける」を押すとSection 1に戻る
- [ ] セクション行のどこをタップしても遷移する
- [ ] 正解/不正解でハプティクスが異なる振動で鳴る
- [ ] セクションの進捗が「0/10」→「3/10」と更新される
- [ ] 管理画面のユーザー詳細で回答ログが確認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)