### PR TITLE
fix: GET /statusを認証不要エンドポイントに追加

### DIFF
--- a/app/internal/auth/middleware.go
+++ b/app/internal/auth/middleware.go
@@ -18,6 +18,7 @@ const UserSubContextKey contextKey = "user_sub"
 var publicOperations = map[string]bool{
 	"Root":            true,
 	"HealthCheck":     true,
+	"GetAppStatus":    true,
 	"GetQuestions":    true,
 	"GetQuestion":     true,
 	"GetCategories":   true,


### PR DESCRIPTION
## Summary

- `GET /status` がauth middlewareで弾かれていたため `publicOperations` に追加

## Test plan

- [ ] `curl https://api.dev.rikako.jp/status` が認証なしで200を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)