### PR TITLE
feature: 管理画面にメンテナンスモード切り替え画面を追加

### DIFF
--- a/admin/src/app/app-status/page.tsx
+++ b/admin/src/app/app-status/page.tsx
@@ -1,0 +1,5 @@
+import { AppStatusForm } from "@/components/app-status/app-status-form";
+
+export default function AppStatusPage() {
+  return <AppStatusForm />;
+}

--- a/admin/src/components/app-status/app-status-form.tsx
+++ b/admin/src/components/app-status/app-status-form.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fetchAppStatus, updateAppStatus } from "@/lib/api/app-status";
+import type { AppStatus } from "@/lib/api/types";
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function AppStatusForm() {
+  const [status, setStatus] = useState<AppStatus | null>(null);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchAppStatus()
+      .then((data) => {
+        setStatus(data);
+        setMessage(data.maintenanceMessage);
+      })
+      .catch(() => toast.error("ステータスの取得に失敗しました"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleToggle = async () => {
+    if (!status) return;
+    setSaving(true);
+    try {
+      const updated = await updateAppStatus({
+        isMaintenance: !status.isMaintenance,
+        maintenanceMessage: message,
+      });
+      setStatus(updated);
+      setMessage(updated.maintenanceMessage);
+      toast.success(
+        updated.isMaintenance
+          ? "メンテナンスモードを有効にしました"
+          : "メンテナンスモードを解除しました",
+      );
+    } catch {
+      toast.error("更新に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSaveMessage = async () => {
+    if (!status) return;
+    setSaving(true);
+    try {
+      const updated = await updateAppStatus({
+        isMaintenance: status.isMaintenance,
+        maintenanceMessage: message,
+      });
+      setStatus(updated);
+      toast.success("メッセージを保存しました");
+    } catch {
+      toast.error("更新に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        読み込み中...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">アプリステータス</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>メンテナンスモード</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">現在の状態</p>
+              <div className="flex items-center gap-2">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                    status?.isMaintenance
+                      ? "bg-destructive/10 text-destructive"
+                      : "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400"
+                  }`}
+                >
+                  {status?.isMaintenance ? "メンテナンス中" : "通常運転"}
+                </span>
+                {status?.updatedAt && (
+                  <span className="text-xs text-muted-foreground">
+                    最終更新: {formatDate(status.updatedAt)}
+                  </span>
+                )}
+              </div>
+            </div>
+            <Button
+              variant={status?.isMaintenance ? "outline" : "destructive"}
+              onClick={handleToggle}
+              disabled={saving}
+            >
+              {saving && <Loader2 className="animate-spin" />}
+              {status?.isMaintenance ? "メンテナンス解除" : "メンテナンス開始"}
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="maintenance-message">メンテナンスメッセージ</Label>
+            <Textarea
+              id="maintenance-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="メンテナンス中に表示するメッセージ"
+              rows={3}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSaveMessage}
+              disabled={saving}
+            >
+              {saving && <Loader2 className="animate-spin" />}
+              メッセージを保存
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/admin/src/components/layout/sidebar.tsx
+++ b/admin/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BookOpen, FileQuestion, FolderOpen, Upload, Loader2, Users, AppWindow } from "lucide-react";
+import { BookOpen, FileQuestion, FolderOpen, Upload, Loader2, Users, AppWindow, WrenchIcon } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { apiPost } from "@/lib/api/client";
@@ -15,6 +15,7 @@ const navigation = [
   { name: "問題", href: "/questions", icon: FileQuestion },
   { name: "ユーザー", href: "/users", icon: Users },
   { name: "アプリ", href: "/apps", icon: AppWindow },
+  { name: "ステータス", href: "/app-status", icon: WrenchIcon },
 ];
 
 export function Sidebar() {

--- a/admin/src/lib/api/app-status.ts
+++ b/admin/src/lib/api/app-status.ts
@@ -1,0 +1,12 @@
+import { apiGet, apiPut } from "@/lib/api/client";
+import type { AppStatus, UpdateAppStatusRequest } from "@/lib/api/types";
+
+export async function fetchAppStatus(): Promise<AppStatus> {
+  return apiGet<AppStatus>("/app-status");
+}
+
+export async function updateAppStatus(
+  data: UpdateAppStatusRequest,
+): Promise<AppStatus> {
+  return apiPut<AppStatus>("/app-status", data);
+}

--- a/admin/src/lib/api/types.ts
+++ b/admin/src/lib/api/types.ts
@@ -178,3 +178,14 @@ export interface ApiError {
   code: string;
   message: string;
 }
+
+export interface AppStatus {
+  isMaintenance: boolean;
+  maintenanceMessage: string;
+  updatedAt: string;
+}
+
+export interface UpdateAppStatusRequest {
+  isMaintenance: boolean;
+  maintenanceMessage: string;
+}


### PR DESCRIPTION
## Summary

- サイドバーに「ステータス」メニューを追加
- `/app-status` ページでメンテナンスモードのON/OFFと表示メッセージを管理できる

## 変更内容

- `admin/src/app/app-status/page.tsx` — ページ追加
- `admin/src/components/app-status/app-status-form.tsx` — メンテナンス切り替えUI
- `admin/src/lib/api/app-status.ts` — `GET/PUT /app-status` APIクライアント
- `admin/src/lib/api/types.ts` — `AppStatus` / `UpdateAppStatusRequest` 型追加
- `admin/src/components/layout/sidebar.tsx` — ナビゲーションに「ステータス」追加

## UI

- 現在の状態（通常運転 / メンテナンス中）をバッジで表示
- 「メンテナンス開始 / 解除」ボタンでワンクリック切り替え
- メンテナンスメッセージを別途保存可能

## Test plan

- [ ] サイドバーに「ステータス」が表示されること
- [ ] ページを開くと現在の状態が取得・表示されること
- [ ] ボタンでメンテナンスモードをON/OFFできること
- [ ] メッセージを保存できること
- [ ] `GET /status`（公開API）の `isMaintenance` が連動して変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)