### PR TITLE
feature: デバッグ画面を強化（学習ログ・問題集確認・セクション分け）

### DIFF
--- a/ios/Rikako/AppState.swift
+++ b/ios/Rikako/AppState.swift
@@ -18,6 +18,11 @@ final class AppState {
         AppState(userDefaults: UserDefaults(suiteName: "jp.conol.rikako.preview.\(UUID().uuidString)")!)
     }
 
+    struct QuestionResult: Codable {
+        let isCorrect: Bool
+        let date: Date
+    }
+
     private enum DefaultsKey {
         static let hasCompletedOnboarding = "jp.conol.rikako.hasCompletedOnboarding"
         static let anonymousUserId = "jp.conol.rikako.anonymousUserId"
@@ -27,6 +32,7 @@ final class AppState {
         static let weeklyCompletedWorkbookIDs = "jp.conol.rikako.weeklyCompletedWorkbookIDs"
         static let currentWeekKey = "jp.conol.rikako.currentWeekKey"
         static let questionResults = "jp.conol.rikako.questionResults"
+        static let questionResultsV2 = "jp.conol.rikako.questionResultsV2"
     }
 
     var hasCompletedOnboarding: Bool
@@ -43,8 +49,8 @@ final class AppState {
     private(set) var weeklyAnswered: Int
     private(set) var weeklyCorrect: Int
     private(set) var weeklyCompletedWorkbookIDs: Set<Int64>
-    // 問題IDごとの最新の正解/不正解 [questionId(String): isCorrect]
-    private(set) var questionResults: [String: Bool]
+    // 問題IDごとの最新の正解/不正解と日時
+    private(set) var questionResults: [String: QuestionResult]
     private let userDefaults: UserDefaults
 
     private init(userDefaults: UserDefaults = .standard) {
@@ -60,7 +66,16 @@ final class AppState {
         self.completedWorkbookIDs = []
         self.wrongQuestions = []
         self.studyDates = Set(userDefaults.stringArray(forKey: DefaultsKey.studyDates) ?? [])
-        self.questionResults = (userDefaults.dictionary(forKey: DefaultsKey.questionResults) as? [String: Bool]) ?? [:]
+
+        // v2形式をロード。なければ旧[String:Bool]からマイグレーション
+        if let data = userDefaults.data(forKey: DefaultsKey.questionResultsV2),
+           let decoded = try? JSONDecoder().decode([String: QuestionResult].self, from: data) {
+            self.questionResults = decoded
+        } else if let legacy = userDefaults.dictionary(forKey: DefaultsKey.questionResults) as? [String: Bool] {
+            self.questionResults = legacy.mapValues { QuestionResult(isCorrect: $0, date: Date(timeIntervalSince1970: 0)) }
+        } else {
+            self.questionResults = [:]
+        }
 
         let savedWeek = userDefaults.string(forKey: DefaultsKey.currentWeekKey) ?? ""
         let currentWeek = AppState.isoWeekKey(for: Date())
@@ -131,6 +146,7 @@ final class AppState {
         userDefaults.removeObject(forKey: DefaultsKey.currentWeekKey)
         questionResults = [:]
         userDefaults.removeObject(forKey: DefaultsKey.questionResults)
+        userDefaults.removeObject(forKey: DefaultsKey.questionResultsV2)
     }
 
     func selectWorkbook(_ workbookID: Int64) {
@@ -174,11 +190,14 @@ final class AppState {
         userDefaults.set(weeklyCorrect, forKey: DefaultsKey.weeklyCorrect)
         userDefaults.set(Array(weeklyCompletedWorkbookIDs), forKey: DefaultsKey.weeklyCompletedWorkbookIDs)
 
-        // 問題ごとの正解/不正解を更新
+        // 問題ごとの正解/不正解と日時を更新
+        let now = Date()
         for (question, answer) in answeredPairs {
-            questionResults[String(question.id)] = (answer == question.correctIndex)
+            questionResults[String(question.id)] = QuestionResult(isCorrect: answer == question.correctIndex, date: now)
         }
-        userDefaults.set(questionResults, forKey: DefaultsKey.questionResults)
+        if let data = try? JSONEncoder().encode(questionResults) {
+            userDefaults.set(data, forKey: DefaultsKey.questionResultsV2)
+        }
 
         var latestWrongQuestions = wrongQuestions
         for (question, answer) in answeredPairs {

--- a/ios/Rikako/Screen/Settings/DebugLearningLogView.swift
+++ b/ios/Rikako/Screen/Settings/DebugLearningLogView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct DebugLearningLogView: View {
+    @Environment(AppState.self) private var appState
+    @State private var visibleCount = 50
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MM/dd HH:mm:ss"
+        return f
+    }()
+
+    private var sortedQuestionResults: [(id: String, result: AppState.QuestionResult)] {
+        appState.questionResults
+            .map { (id: $0.key, result: $0.value) }
+            .sorted { $0.result.date > $1.result.date }
+    }
+
+    var body: some View {
+        List {
+            if appState.questionResults.isEmpty {
+                ContentUnavailableView("まだ解いた問題がありません", systemImage: "square.and.pencil")
+            } else {
+                ForEach(sortedQuestionResults.prefix(visibleCount), id: \.id) { entry in
+                    HStack(spacing: 10) {
+                        Image(systemName: entry.result.isCorrect ? "circle" : "xmark")
+                            .foregroundStyle(entry.result.isCorrect ? .green : .red)
+                            .frame(width: 16)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("問題 ID: \(entry.id)")
+                                .font(.caption)
+                            Text(Self.dateFormatter.string(from: entry.result.date))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(entry.result.isCorrect ? "正解" : "不正解")
+                            .font(.caption)
+                            .foregroundStyle(entry.result.isCorrect ? .green : .red)
+                    }
+                }
+                if visibleCount < sortedQuestionResults.count {
+                    Button("もっと見る (\(sortedQuestionResults.count - visibleCount)件)") {
+                        visibleCount += 50
+                    }
+                    .font(.caption)
+                }
+            }
+        }
+        .navigationTitle("学習ログ (\(appState.questionResults.count)問)")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/Rikako/Screen/Settings/DebugView.swift
+++ b/ios/Rikako/Screen/Settings/DebugView.swift
@@ -5,15 +5,19 @@ struct DebugView: View {
 
     var body: some View {
         List {
-            Section("ユーザー情報") {
+            Section("ユーザー") {
                 row(title: "User ID", value: appState.userId.map { String($0) } ?? "未設定")
                 row(title: "Identity ID", value: appState.anonymousUserId ?? "未設定")
                 row(title: "表示名", value: appState.displayName ?? "未設定")
             }
 
-            Section("アプリ情報") {
-                row(title: "バージョン", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-")
-                row(title: "ビルド番号", value: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-")
+            Section("コンテンツ") {
+                NavigationLink(destination: DebugWorkbooksView()) {
+                    Label("問題集", systemImage: "books.vertical")
+                }
+                NavigationLink(destination: DebugLearningLogView()) {
+                    Label("学習ログ (\(appState.questionResults.count)問)", systemImage: "square.and.pencil")
+                }
             }
         }
         .navigationTitle("デバッグ")

--- a/ios/Rikako/Screen/Settings/DebugWorkbooksView.swift
+++ b/ios/Rikako/Screen/Settings/DebugWorkbooksView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+// MARK: - 問題集一覧
+
+struct DebugWorkbooksView: View {
+    @State private var workbooks: [Workbook] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("読み込み中...")
+            } else if let errorMessage {
+                ContentUnavailableView {
+                    Label("読み込みエラー", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("再読み込み") { Task { await load() } }
+                }
+            } else if workbooks.isEmpty {
+                ContentUnavailableView("問題集がありません", systemImage: "book")
+            } else {
+                List {
+                    ForEach(workbooks) { workbook in
+                        NavigationLink(destination: DebugWorkbookDetailView(workbookID: workbook.id)) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(workbook.title).font(.headline)
+                                Text("\(workbook.questionCount)問").font(.caption).foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("問題集 (Debug)")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            workbooks = try await AppContainer.shared.learningUseCases.fetchWorkbooks.execute()
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - 問題一覧
+
+struct DebugWorkbookDetailView: View {
+    let workbookID: Int64
+    @State private var workbook: WorkbookDetail?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("読み込み中...")
+            } else if let errorMessage {
+                ContentUnavailableView {
+                    Label("読み込みエラー", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("再読み込み") { Task { await load() } }
+                }
+            } else if let workbook {
+                List {
+                    ForEach(Array(workbook.questions.enumerated()), id: \.element.id) { index, question in
+                        NavigationLink(destination: DebugQuestionDetailView(index: index + 1, question: question)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Q\(index + 1)").font(.caption.bold()).foregroundStyle(.secondary)
+                                Text(question.text).font(.subheadline).lineLimit(2)
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                }
+                .navigationTitle(workbook.title)
+            } else {
+                ContentUnavailableView("問題集が見つかりません", systemImage: "exclamationmark.triangle")
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            workbook = try await AppContainer.shared.learningUseCases.fetchWorkbookDetail.execute(id: workbookID)
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - 問題詳細
+
+struct DebugQuestionDetailView: View {
+    let index: Int
+    let question: Question
+
+    var body: some View {
+        List {
+            Section("問題") {
+                Text(question.text)
+                    .font(.body)
+                    .textSelection(.enabled)
+            }
+
+            Section("選択肢") {
+                ForEach(Array(question.choices.enumerated()), id: \.offset) { i, choice in
+                    HStack(spacing: 10) {
+                        Image(systemName: i == question.correctIndex ? "circle.fill" : "circle")
+                            .foregroundStyle(i == question.correctIndex ? .green : .secondary)
+                            .frame(width: 20)
+                        Text(choice)
+                            .font(.subheadline)
+                            .foregroundStyle(i == question.correctIndex ? .primary : .secondary)
+                        if i == question.correctIndex {
+                            Spacer()
+                            Text("正解").font(.caption.bold()).foregroundStyle(.green)
+                        }
+                    }
+                }
+            }
+
+            if let explanation = question.explanation, !explanation.isEmpty {
+                Section("解説") {
+                    Text(explanation)
+                        .font(.subheadline)
+                        .textSelection(.enabled)
+                }
+            }
+
+            Section("メタ情報") {
+                row(title: "問題ID", value: String(question.id))
+                row(title: "種別", value: question.type.rawValue)
+                if let images = question.images, !images.isEmpty {
+                    row(title: "画像数", value: "\(images.count)枚")
+                }
+            }
+        }
+        .navigationTitle("Q\(index) (Debug)")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func row(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value).foregroundStyle(.secondary).font(.caption).textSelection(.enabled)
+        }
+    }
+}

--- a/ios/Rikako/Screen/Settings/SettingsView.swift
+++ b/ios/Rikako/Screen/Settings/SettingsView.swift
@@ -38,6 +38,7 @@ struct SettingsView: View {
 
             VStack(spacing: 0) {
                 infoRow(symbol: "info.circle.fill", title: "バージョン", trailing: viewModel.versionText, accentColor: .blue)
+                    .contentShape(Rectangle())
                     .onTapGesture {
                         versionTapCount += 1
                         if versionTapCount >= 3 {

--- a/ios/Rikako/Screen/StudyHome/StudyHomeViewModel.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeViewModel.swift
@@ -91,14 +91,14 @@ final class StudyHomeViewModel {
     }
 
     // セクションの正解数と回答済み数を返す
-    func sectionProgress(for section: Section, questionResults: [String: Bool]) -> (correct: Int, answered: Int) {
+    func sectionProgress(for section: Section, questionResults: [String: AppState.QuestionResult]) -> (correct: Int, answered: Int) {
         let qs = questions(for: section)
         var correct = 0
         var answered = 0
         for q in qs {
-            if let isCorrect = questionResults[String(q.id)] {
+            if let result = questionResults[String(q.id)] {
                 answered += 1
-                if isCorrect { correct += 1 }
+                if result.isCorrect { correct += 1 }
             }
         }
         return (correct, answered)


### PR DESCRIPTION
## Summary

- バージョン行のタップ領域をスペース含め全体に拡張（`contentShape(Rectangle())`）
- `QuestionResult` 構造体を追加して解答日時を記録、旧 `[String: Bool]` からの自動マイグレーション付き
- デバッグ画面をメニュー形式にセクション分け（バージョン情報は削除）
- 学習ログをサブ画面に分離、日時付き・新しい順・50件ずつページング
- 問題集確認を3階層で追加（問題集一覧 → 問題一覧 → 問題詳細：選択肢・正解・解説）

## Test plan

- [ ] バージョン情報をスペース部分含めて3回タップするとデバッグ画面に遷移すること
- [ ] デバッグ画面から「問題集」に遷移し、問題集→問題→解説を確認できること
- [ ] デバッグ画面から「学習ログ」に遷移し、解答済み問題が日時付きで新しい順に表示されること
- [ ] 学習ログが50件を超えると「もっと見る」ボタンが表示されること
- [ ] ログアウト後に学習ログがリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)