### PR TITLE
クイズ完了後にStudyHomeViewの進捗を更新する

### DIFF
--- a/ios/Rikako/AppState.swift
+++ b/ios/Rikako/AppState.swift
@@ -21,6 +21,7 @@ final class AppState {
     var userId: Int64?
     var displayName: String?
     var selectedWorkbookID: Int64?
+    var lastQuizCompletionID: Int = 0
     private let userDefaults: UserDefaults
 
     private init(userDefaults: UserDefaults = .standard) {
@@ -54,6 +55,10 @@ final class AppState {
         userDefaults.removeObject(forKey: DefaultsKey.hasCompletedOnboarding)
         userDefaults.removeObject(forKey: DefaultsKey.anonymousUserId)
         userDefaults.removeObject(forKey: DefaultsKey.selectedWorkbookID)
+    }
+
+    func notifyQuizCompleted() {
+        lastQuizCompletionID += 1
     }
 
     func selectWorkbook(_ workbookID: Int64) {

--- a/ios/Rikako/Screen/Quiz/QuizView.swift
+++ b/ios/Rikako/Screen/Quiz/QuizView.swift
@@ -66,7 +66,11 @@ struct QuizView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
-                    showExitConfirmation = true
+                    if viewModel.answers.allSatisfy({ $0 == nil }) {
+                        dismiss()
+                    } else {
+                        showExitConfirmation = true
+                    }
                 } label: {
                     Image(systemName: "chevron.left")
                 }
@@ -79,6 +83,7 @@ struct QuizView: View {
             }
             Button("履歴を保存して戻る") {
                 viewModel.submitAnswers()
+                appState.notifyQuizCompleted()
                 dismiss()
             }
             Button("キャンセル", role: .cancel) {}

--- a/ios/Rikako/Screen/Result/ResultView.swift
+++ b/ios/Rikako/Screen/Result/ResultView.swift
@@ -45,6 +45,7 @@ struct ResultView: View {
         .toolbar(.hidden, for: .tabBar)
         .task {
             viewModel.recordSessionIfNeeded()
+            appState.notifyQuizCompleted()
         }
     }
 

--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -79,6 +79,10 @@ struct StudyHomeView: View {
             await viewModel.loadSelectedWorkbookDetail(selectedWorkbookID: appState.selectedWorkbookID)
             await loadWorkbookProgress()
         }
+        .task(id: appState.lastQuizCompletionID) {
+            guard !isPreview, appState.lastQuizCompletionID > 0 else { return }
+            await loadWorkbookProgress()
+        }
     }
 
     private func loadWorkbookProgress() async {


### PR DESCRIPTION
## Summary

- `AppState`に`lastQuizCompletionID`カウンタと`notifyQuizCompleted()`を追加
- ResultView（正常フロー）とQuizViewの離脱アラート（途中離脱フロー）の両方でクイズ完了を通知
- StudyHomeViewが`lastQuizCompletionID`の変化を`.task(id:)`で監視し、`workbookProgress`を再取得
- 1問も解いていない状態で戻るボタンを押した場合はアラートを表示せず即座に戻るように修正

## Test plan

- [ ] クイズを最後まで解いてResultViewから「問題集一覧に戻る」→ セクションの正解数が更新されていることを確認
- [ ] クイズ途中で「履歴を保存して戻る」→ セクションの正解数が更新されていることを確認
- [ ] クイズ途中で「戻る（保存しない）」→ 正解数が変わらないことを確認
- [ ] 1問も解かずに戻るボタン → アラートなしで即座に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)