### PR TITLE
Add: クイズ回答時の効果音と触覚フィードバック設定を追加

### DIFF
--- a/ios/Rikako/Screen/Quiz/QuizView.swift
+++ b/ios/Rikako/Screen/Quiz/QuizView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import AudioToolbox
 
 struct QuizView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
     @State private var viewModel: QuizViewModel
+    @AppStorage(UserPreferencesKey.soundEnabled) private var isSoundEnabled = true
+    @AppStorage(UserPreferencesKey.hapticEnabled) private var isHapticEnabled = true
     @State private var isNextButtonVisible = false
     @State private var scrollViewHeight: CGFloat = 0
     @State private var showExitConfirmation = false
@@ -145,11 +148,17 @@ struct QuizView: View {
         VStack(spacing: 12) {
             ForEach(Array(viewModel.currentQuestion.choices.enumerated()), id: \.offset) { index, choice in
                 Button {
+                    let isCorrect = index == viewModel.currentQuestion.correctIndex
                     withAnimation {
                         viewModel.selectChoice(index)
                     }
-                    let feedback = UINotificationFeedbackGenerator()
-                    feedback.notificationOccurred(index == viewModel.currentQuestion.correctIndex ? .success : .error)
+                    if isHapticEnabled {
+                        let feedback = UINotificationFeedbackGenerator()
+                        feedback.notificationOccurred(isCorrect ? .success : .error)
+                    }
+                    if isSoundEnabled {
+                        AudioServicesPlaySystemSound(isCorrect ? 1057 : 1073)
+                    }
                 } label: {
                     HStack(spacing: 14) {
                         Text(choiceLabel(for: index))

--- a/ios/Rikako/Screen/Settings/SettingsView.swift
+++ b/ios/Rikako/Screen/Settings/SettingsView.swift
@@ -6,10 +6,13 @@ struct SettingsView: View {
     @State private var showLogoutConfirmation = false
     @State private var versionTapCount = 0
     @State private var showDebug = false
+    @AppStorage(UserPreferencesKey.soundEnabled) private var isSoundEnabled = true
+    @AppStorage(UserPreferencesKey.hapticEnabled) private var isHapticEnabled = true
 
     var body: some View {
         ScrollView {
             VStack(spacing: 18) {
+                feedbackCard
                 aboutCard
                 logoutButton
             }
@@ -29,6 +32,20 @@ struct SettingsView: View {
             }
         } message: {
             Text("ログアウトすると学習データがリセットされます。よろしいですか？")
+        }
+    }
+
+    private var feedbackCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle("サウンド・フィードバック")
+
+            VStack(spacing: 0) {
+                toggleRow(symbol: "speaker.wave.2.fill", title: "効果音", accentColor: .purple, isOn: $isSoundEnabled)
+                Divider().padding(.leading, 48)
+                toggleRow(symbol: "hand.tap.fill", title: "触覚フィードバック", accentColor: .orange, isOn: $isHapticEnabled)
+            }
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 18))
         }
     }
 
@@ -79,6 +96,28 @@ struct SettingsView: View {
         Text(title)
             .font(.headline.bold())
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func toggleRow(symbol: String, title: String, accentColor: Color, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: symbol)
+                .font(.subheadline.bold())
+                .foregroundStyle(accentColor)
+                .frame(width: 28, height: 28)
+                .background(accentColor.opacity(0.10))
+                .clipShape(Circle())
+
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.primary)
+
+            Spacer()
+
+            Toggle("", isOn: isOn)
+                .labelsHidden()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
     }
 
     private func infoRow(symbol: String, title: String, trailing: String? = nil, accentColor: Color) -> some View {

--- a/ios/Rikako/Screen/Settings/SettingsViewModel.swift
+++ b/ios/Rikako/Screen/Settings/SettingsViewModel.swift
@@ -10,3 +10,8 @@ final class SettingsViewModel {
         return "\(version) (\(build))"
     }
 }
+
+enum UserPreferencesKey {
+    static let soundEnabled = "soundEnabled"
+    static let hapticEnabled = "hapticEnabled"
+}


### PR DESCRIPTION
## Summary
- 正解・不正解時にシステムサウンドを再生（正解: Tink / 不正解: Tock）
- 設定画面に「効果音」「触覚フィードバック」のトグルを追加
- 設定は `UserDefaults` に保存され、アプリ再起動後も維持される

## Test plan
- [ ] クイズで正解を選ぶと効果音（Tink）とハプティクスが鳴る
- [ ] クイズで不正解を選ぶと効果音（Tock）とハプティクスが鳴る
- [ ] 設定画面で効果音をオフにすると音が鳴らない
- [ ] 設定画面で触覚フィードバックをオフにすると振動しない
- [ ] 設定を変更してアプリを再起動しても設定が保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)