### PR TITLE
Add: お知らせ管理画面 (admin Next.js)

### DIFF
--- a/admin/src/app/announcements/[[...slug]]/page.tsx
+++ b/admin/src/app/announcements/[[...slug]]/page.tsx
@@ -1,0 +1,9 @@
+import { AnnouncementsRouter } from "@/components/announcements/announcements-router";
+
+export async function generateStaticParams() {
+  return [{ slug: [] }];
+}
+
+export default function AnnouncementsPage() {
+  return <AnnouncementsRouter />;
+}

--- a/admin/src/components/announcements/announcement-detail.tsx
+++ b/admin/src/components/announcements/announcement-detail.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAnnouncement } from "@/hooks/use-announcements";
+import { deleteAnnouncement } from "@/lib/api/announcements";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+function formatDateTime(iso: string) {
+  const d = new Date(iso);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function categoryLabel(value: string): string {
+  switch (value) {
+    case "release":
+      return "リリース";
+    case "maintenance":
+      return "メンテナンス";
+    case "info":
+      return "お知らせ";
+    default:
+      return value;
+  }
+}
+
+export function AnnouncementDetail({ id }: { id: number }) {
+  const { data, error, isLoading } = useAnnouncement(id);
+  const router = useRouter();
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await deleteAnnouncement(id);
+      toast.success("お知らせを削除しました");
+      router.push("/announcements");
+    } catch {
+      toast.error("お知らせの削除に失敗しました");
+      setDeleting(false);
+    }
+  }
+
+  if (isLoading) return <p className="text-muted-foreground">読み込み中...</p>;
+  if (error) return <p className="text-destructive">エラーが発生しました</p>;
+  if (!data) return null;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">お知らせ詳細</h1>
+        <div className="flex gap-2">
+          <Link
+            href={`/announcements/${id}/edit`}
+            className={buttonVariants({ variant: "outline" })}
+          >
+            <Pencil className="mr-2 h-4 w-4" />
+            編集
+          </Link>
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={<Button variant="destructive" disabled={deleting} />}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              削除
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>お知らせを削除しますか？</AlertDialogTitle>
+                <AlertDialogDescription>
+                  この操作は取り消せません。
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDelete}>
+                  削除
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">{categoryLabel(data.category)}</Badge>
+            <span className="text-sm text-muted-foreground">
+              {formatDateTime(data.publishedAt)}
+            </span>
+          </div>
+          <CardTitle className="mt-2">{data.title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed">
+            {data.body}
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/admin/src/components/announcements/announcement-edit.tsx
+++ b/admin/src/components/announcements/announcement-edit.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAnnouncement } from "@/hooks/use-announcements";
+import { updateAnnouncement } from "@/lib/api/announcements";
+import { AnnouncementForm } from "@/components/announcements/announcement-form";
+import { toast } from "sonner";
+
+export function AnnouncementEdit({ id }: { id: number }) {
+  const { data, error, isLoading } = useAnnouncement(id);
+  const router = useRouter();
+
+  if (isLoading) return <p className="text-muted-foreground">読み込み中...</p>;
+  if (error) return <p className="text-destructive">エラーが発生しました</p>;
+  if (!data) return null;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold">お知らせ編集</h1>
+      <AnnouncementForm
+        defaultValues={data}
+        submitLabel="更新"
+        onSubmit={async (values) => {
+          try {
+            await updateAnnouncement(id, values);
+            toast.success("お知らせを更新しました");
+            router.push(`/announcements/${id}`);
+          } catch {
+            toast.error("お知らせの更新に失敗しました");
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/admin/src/components/announcements/announcement-form.tsx
+++ b/admin/src/components/announcements/announcement-form.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+import type { Announcement } from "@/lib/api/types";
+
+const schema = z.object({
+  title: z.string().min(1, "タイトルを入力してください"),
+  body: z.string().min(1, "本文を入力してください"),
+  category: z.string().min(1, "種別を選択してください"),
+  publishedAt: z.string().min(1, "公開日時を入力してください"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const CATEGORIES = [
+  { value: "info", label: "お知らせ" },
+  { value: "release", label: "リリース" },
+  { value: "maintenance", label: "メンテナンス" },
+];
+
+interface AnnouncementFormProps {
+  defaultValues?: Announcement;
+  onSubmit: (data: {
+    title: string;
+    body: string;
+    category: string;
+    publishedAt: string;
+  }) => Promise<void>;
+  submitLabel: string;
+}
+
+function toLocalDateTimeInput(iso: string | undefined): string {
+  const d = iso ? new Date(iso) : new Date();
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function AnnouncementForm({
+  defaultValues,
+  onSubmit,
+  submitLabel,
+}: AnnouncementFormProps) {
+  const [submitting, setSubmitting] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      title: defaultValues?.title ?? "",
+      body: defaultValues?.body ?? "",
+      category: defaultValues?.category ?? "info",
+      publishedAt: toLocalDateTimeInput(defaultValues?.publishedAt),
+    },
+  });
+
+  async function onFormSubmit(values: FormValues) {
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: values.title,
+        body: values.body,
+        category: values.category,
+        publishedAt: new Date(values.publishedAt).toISOString(),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="title">タイトル</Label>
+        <Input
+          id="title"
+          {...register("title")}
+          placeholder="お知らせのタイトル"
+        />
+        {errors.title && (
+          <p className="text-sm text-destructive">{errors.title.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="category">種別</Label>
+        <select
+          id="category"
+          {...register("category")}
+          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+        >
+          {CATEGORIES.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+        {errors.category && (
+          <p className="text-sm text-destructive">{errors.category.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="publishedAt">公開日時</Label>
+        <Input
+          id="publishedAt"
+          type="datetime-local"
+          {...register("publishedAt")}
+        />
+        {errors.publishedAt && (
+          <p className="text-sm text-destructive">{errors.publishedAt.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="body">本文（Markdown）</Label>
+        <Textarea
+          id="body"
+          {...register("body")}
+          placeholder="Markdown で記述できます"
+          rows={12}
+          className="font-mono"
+        />
+        {errors.body && (
+          <p className="text-sm text-destructive">{errors.body.message}</p>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/admin/src/components/announcements/announcement-list.tsx
+++ b/admin/src/components/announcements/announcement-list.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useAnnouncements } from "@/hooks/use-announcements";
+import { AnnouncementTable } from "@/components/announcements/announcement-table";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
+
+const PAGE_SIZE = 20;
+
+export function AnnouncementList() {
+  const [page, setPage] = useState(0);
+  const { data, error, isLoading } = useAnnouncements(
+    PAGE_SIZE,
+    page * PAGE_SIZE,
+  );
+
+  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">お知らせ一覧</h1>
+        <Link href="/announcements/new" className={buttonVariants()}>
+          <Plus className="mr-2 h-4 w-4" />
+          新規作成
+        </Link>
+      </div>
+
+      {isLoading && <p className="text-muted-foreground">読み込み中...</p>}
+      {error && <p className="text-destructive">エラーが発生しました</p>}
+
+      {data && (
+        <>
+          {data.announcements.length === 0 ? (
+            <p className="text-muted-foreground">お知らせがありません</p>
+          ) : (
+            <AnnouncementTable announcements={data.announcements} />
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {page + 1} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/admin/src/components/announcements/announcement-new.tsx
+++ b/admin/src/components/announcements/announcement-new.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { AnnouncementForm } from "@/components/announcements/announcement-form";
+import { createAnnouncement } from "@/lib/api/announcements";
+import { toast } from "sonner";
+
+export function AnnouncementNew() {
+  const router = useRouter();
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold">お知らせ作成</h1>
+      <AnnouncementForm
+        submitLabel="作成"
+        onSubmit={async (data) => {
+          try {
+            const a = await createAnnouncement(data);
+            toast.success("お知らせを作成しました");
+            router.push(`/announcements/${a.id}`);
+          } catch {
+            toast.error("お知らせの作成に失敗しました");
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/admin/src/components/announcements/announcement-table.tsx
+++ b/admin/src/components/announcements/announcement-table.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import type { Announcement } from "@/lib/api/types";
+
+interface AnnouncementTableProps {
+  announcements: Announcement[];
+}
+
+function formatDateTime(iso: string) {
+  const d = new Date(iso);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function categoryLabel(value: string): string {
+  switch (value) {
+    case "release":
+      return "リリース";
+    case "maintenance":
+      return "メンテナンス";
+    case "info":
+      return "お知らせ";
+    default:
+      return value;
+  }
+}
+
+export function AnnouncementTable({ announcements }: AnnouncementTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-16">ID</TableHead>
+          <TableHead className="w-28">種別</TableHead>
+          <TableHead>タイトル</TableHead>
+          <TableHead className="w-40">公開日時</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {announcements.map((a) => (
+          <TableRow key={a.id}>
+            <TableCell>{a.id}</TableCell>
+            <TableCell>
+              <Badge variant="secondary">{categoryLabel(a.category)}</Badge>
+            </TableCell>
+            <TableCell>
+              <Link
+                href={`/announcements/${a.id}`}
+                className="hover:underline"
+              >
+                {a.title}
+              </Link>
+            </TableCell>
+            <TableCell className="text-muted-foreground">
+              {formatDateTime(a.publishedAt)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/admin/src/components/announcements/announcements-router.tsx
+++ b/admin/src/components/announcements/announcements-router.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useRouteSlug } from "@/hooks/use-route-slug";
+import { AnnouncementList } from "@/components/announcements/announcement-list";
+import { AnnouncementNew } from "@/components/announcements/announcement-new";
+import { AnnouncementDetail } from "@/components/announcements/announcement-detail";
+import { AnnouncementEdit } from "@/components/announcements/announcement-edit";
+
+export function AnnouncementsRouter() {
+  const { slug, mounted } = useRouteSlug("announcements");
+
+  if (!mounted) {
+    return <p className="text-muted-foreground">読み込み中...</p>;
+  }
+
+  if (!slug || slug.length === 0) {
+    return <AnnouncementList />;
+  }
+
+  if (slug[0] === "new") {
+    return <AnnouncementNew />;
+  }
+
+  const id = Number(slug[0]);
+
+  if (slug[1] === "edit") {
+    return <AnnouncementEdit id={id} />;
+  }
+
+  return <AnnouncementDetail id={id} />;
+}

--- a/admin/src/components/layout/sidebar.tsx
+++ b/admin/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BookOpen, FileQuestion, FolderOpen, Upload, Loader2, Users, AppWindow, WrenchIcon } from "lucide-react";
+import { BookOpen, FileQuestion, FolderOpen, Upload, Loader2, Users, AppWindow, WrenchIcon, Megaphone } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { apiPost } from "@/lib/api/client";
@@ -13,6 +13,7 @@ const navigation = [
   { name: "カテゴリ", href: "/categories", icon: FolderOpen },
   { name: "問題集", href: "/workbooks", icon: BookOpen },
   { name: "問題", href: "/questions", icon: FileQuestion },
+  { name: "お知らせ", href: "/announcements", icon: Megaphone },
   { name: "ユーザー", href: "/users", icon: Users },
   { name: "アプリ", href: "/apps", icon: AppWindow },
   { name: "ステータス", href: "/app-status", icon: WrenchIcon },
@@ -27,7 +28,7 @@ export function Sidebar() {
     try {
       const result = await apiPost<PublishResponse>("/publish", {});
       toast.success(
-        `出力完了: カテゴリ ${result.categoriesCount}件、問題集 ${result.workbooksCount}件`,
+        `出力完了: カテゴリ ${result.categoriesCount}件、問題集 ${result.workbooksCount}件、お知らせ ${result.announcementsCount ?? 0}件`,
       );
     } catch {
       toast.error("出力に失敗しました");

--- a/admin/src/hooks/use-announcements.ts
+++ b/admin/src/hooks/use-announcements.ts
@@ -1,0 +1,17 @@
+import useSWR from "swr";
+import { fetchAnnouncements, fetchAnnouncement } from "@/lib/api/announcements";
+import type { Announcement, AnnouncementsResponse } from "@/lib/api/types";
+
+export function useAnnouncements(limit: number, offset: number) {
+  return useSWR<AnnouncementsResponse>(
+    [`/announcements`, limit, offset],
+    () => fetchAnnouncements(limit, offset),
+  );
+}
+
+export function useAnnouncement(id: number | null) {
+  return useSWR<Announcement>(
+    id !== null ? [`/announcements`, id] : null,
+    () => fetchAnnouncement(id!),
+  );
+}

--- a/admin/src/lib/api/announcements.ts
+++ b/admin/src/lib/api/announcements.ts
@@ -1,0 +1,37 @@
+import { apiGet, apiPost, apiPut, apiDelete } from "./client";
+import type {
+  Announcement,
+  AnnouncementsResponse,
+  CreateAnnouncementRequest,
+  UpdateAnnouncementRequest,
+} from "./types";
+
+export function fetchAnnouncements(
+  limit: number,
+  offset: number,
+): Promise<AnnouncementsResponse> {
+  return apiGet<AnnouncementsResponse>(
+    `/announcements?limit=${limit}&offset=${offset}`,
+  );
+}
+
+export function fetchAnnouncement(id: number): Promise<Announcement> {
+  return apiGet<Announcement>(`/announcements/${id}`);
+}
+
+export function createAnnouncement(
+  data: CreateAnnouncementRequest,
+): Promise<Announcement> {
+  return apiPost<Announcement>("/announcements", data);
+}
+
+export function updateAnnouncement(
+  id: number,
+  data: UpdateAnnouncementRequest,
+): Promise<Announcement> {
+  return apiPut<Announcement>(`/announcements/${id}`, data);
+}
+
+export function deleteAnnouncement(id: number): Promise<void> {
+  return apiDelete(`/announcements/${id}`);
+}

--- a/admin/src/lib/api/types.ts
+++ b/admin/src/lib/api/types.ts
@@ -113,6 +113,34 @@ export interface PublishResponse {
   publishedAt: string;
   categoriesCount?: number;
   workbooksCount?: number;
+  announcementsCount?: number;
+}
+
+export interface Announcement {
+  id: number;
+  title: string;
+  body: string;
+  category: string;
+  publishedAt: string;
+}
+
+export interface AnnouncementsResponse {
+  announcements: Announcement[];
+  total: number;
+}
+
+export interface CreateAnnouncementRequest {
+  title: string;
+  body: string;
+  category?: string;
+  publishedAt?: string;
+}
+
+export interface UpdateAnnouncementRequest {
+  title: string;
+  body: string;
+  category?: string;
+  publishedAt?: string;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
Issue #156 のステップ3: admin Next.js にお知らせ管理画面を追加。

- 一覧（最新順、ページネーション20件）
- 詳細
- 新規作成・編集・削除
- 種別セレクト: info / release / maintenance
- 公開日時: datetime-local 入力
- 本文: Markdown（入力はMarkdown、表示は現状プレーン \`<pre>\`）
- サイドバーに「お知らせ」ナビ追加
- PublishResponse に announcementsCount を追加してトースト表示

## 動作確認メモ

- \`npm run build\` 成功
- \`npm run lint\`: 既存の警告・エラー（use-route-slug.ts の1件）はそのまま、本PRで追加された警告なし
- dev サーバでのUI手動確認は未実施（admin API の起動が必要なため、デプロイ後にdev環境で確認予定）

## スコープ外（別PR）
- Markdown レンダラ導入（詳細画面でのHTML表示）
- iOS 実装（次PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)