### PR TITLE
Fix: お知らせ取得エンドポイントを認証不要に追加

### DIFF
--- a/app/internal/auth/middleware.go
+++ b/app/internal/auth/middleware.go
@@ -25,6 +25,8 @@ var publicOperations = map[string]bool{
 	"GetCategory":     true,
 	"GetWorkbooks":    true,
 	"GetWorkbook":     true,
+	"GetAnnouncements": true,
+	"GetAnnouncement":  true,
 	"SubmitAnswers":    true,
 	"GetWrongAnswers":  true,
 	"GetAnswerLogs":       true,

--- a/app/internal/auth/middleware_test.go
+++ b/app/internal/auth/middleware_test.go
@@ -87,6 +87,7 @@ func TestPublicOperationsPassWithoutToken(t *testing.T) {
 		"GetQuestions", "GetQuestion",
 		"GetCategories", "GetCategory",
 		"GetWorkbooks", "GetWorkbook",
+		"GetAnnouncements", "GetAnnouncement",
 	}
 	for _, op := range publicOps {
 		t.Run(op, func(t *testing.T) {


### PR DESCRIPTION
## Summary
\`GET /announcements\` と \`GET /announcements/{id}\` が認証必須になっていたバグの修正。
カテゴリ・問題集と同様、匿名ユーザーから参照される想定のため認証ミドルウェアの allowlist に追加。

refs #156

## Test plan
- [x] \`go test ./internal/auth/\` 通過（テストケースにも追加済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)