### PR TITLE
Add: iOS お知らせ機能 (一覧・詳細・既読管理・設定画面導線)

### DIFF
--- a/ios/Rikako/Data/Remote/Response/AnnouncementListResponse.swift
+++ b/ios/Rikako/Data/Remote/Response/AnnouncementListResponse.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct AnnouncementListResponse: Codable {
+    let announcements: [Announcement]
+    let total: Int
+}

--- a/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
+++ b/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
@@ -122,6 +122,14 @@ final class RemoteLearningRepository: LearningRepository {
         return try await getJSON(url: url, authenticated: true)
     }
 
+    func fetchAnnouncements() async throws -> [Announcement] {
+        let url = contentBaseURL.appendingPathComponent("announcements.json")
+        let (data, response) = try await httpClient.data(from: url)
+        try validateResponse(response)
+        let result = try decoder.decode(AnnouncementListResponse.self, from: data)
+        return result.announcements
+    }
+
     func fetchWrongAnswers(limit: Int, offset: Int) async throws -> WrongAnswerListResponse {
         var components = URLComponents(url: apiBaseURL.appendingPathComponent("users/me/wrong-answers"), resolvingAgainstBaseURL: false)!
         components.queryItems = [

--- a/ios/Rikako/Domain/Entity/Announcement.swift
+++ b/ios/Rikako/Domain/Entity/Announcement.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct Announcement: Identifiable, Codable, Hashable {
+    let id: Int64
+    let title: String
+    let body: String
+    let category: String
+    let publishedAt: Date
+}
+
+extension Announcement {
+    /// 公開日から7日以内かどうか。
+    func isWithinUnreadWindow(now: Date = Date()) -> Bool {
+        let sevenDays: TimeInterval = 7 * 24 * 60 * 60
+        return now.timeIntervalSince(publishedAt) < sevenDays
+    }
+}

--- a/ios/Rikako/Domain/Repository/LearningRepository.swift
+++ b/ios/Rikako/Domain/Repository/LearningRepository.swift
@@ -26,4 +26,5 @@ protocol LearningRepository {
     func anonymousSignIn() async throws -> String
     func fetchUserProfile(appSlug: String) async throws -> UserProfile
     func updateUserProfile(appSlug: String, request: UpdateUserProfileRequest) async throws -> UserProfile
+    func fetchAnnouncements() async throws -> [Announcement]
 }

--- a/ios/Rikako/Domain/UseCase/LearningUseCases.swift
+++ b/ios/Rikako/Domain/UseCase/LearningUseCases.swift
@@ -13,6 +13,7 @@ struct LearningUseCases {
     let fetchUserSummary: FetchUserSummaryUseCase
     let fetchUserProfile: FetchUserProfileUseCase
     let updateUserProfile: UpdateUserProfileUseCase
+    let fetchAnnouncements: FetchAnnouncementsUseCase
 
     init(repository: LearningRepository) {
         self.fetchAppStatus = FetchAppStatusUseCase(repository: repository)
@@ -27,6 +28,19 @@ struct LearningUseCases {
         self.fetchUserSummary = FetchUserSummaryUseCase(repository: repository)
         self.fetchUserProfile = FetchUserProfileUseCase(repository: repository)
         self.updateUserProfile = UpdateUserProfileUseCase(repository: repository)
+        self.fetchAnnouncements = FetchAnnouncementsUseCase(repository: repository)
+    }
+}
+
+struct FetchAnnouncementsUseCase {
+    private let repository: LearningRepository
+
+    init(repository: LearningRepository) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> [Announcement] {
+        try await repository.fetchAnnouncements()
     }
 }
 

--- a/ios/Rikako/Preview/PreviewLearningRepository.swift
+++ b/ios/Rikako/Preview/PreviewLearningRepository.swift
@@ -130,6 +130,33 @@ final class PreviewLearningRepository: LearningRepository {
             total: min(limit, MockData.questions.count)
         )
     }
+
+    func fetchAnnouncements() async throws -> [Announcement] {
+        let now = Date()
+        return [
+            Announcement(
+                id: 1,
+                title: "春のチャレンジ応援キャンペーン",
+                body: "# キャンペーン開催\n期間限定で学習を続けやすい企画を実施中です。\n\n- ログインボーナス\n- 連続学習バッジ",
+                category: "info",
+                publishedAt: now.addingTimeInterval(-60 * 60 * 3)
+            ),
+            Announcement(
+                id: 2,
+                title: "新しい問題集を追加しました",
+                body: "基礎化学の復習に使いやすい問題集を追加しました。",
+                category: "release",
+                publishedAt: now.addingTimeInterval(-60 * 60 * 24 * 2)
+            ),
+            Announcement(
+                id: 3,
+                title: "メンテナンスのお知らせ",
+                body: "一時的にサービスが利用できなくなる可能性があります。",
+                category: "maintenance",
+                publishedAt: now.addingTimeInterval(-60 * 60 * 24 * 10)
+            )
+        ]
+    }
 }
 
 enum PreviewAppContainer {

--- a/ios/Rikako/Screen/MyPage/MyPageView.swift
+++ b/ios/Rikako/Screen/MyPage/MyPageView.swift
@@ -20,6 +20,7 @@ struct MyPageView: View {
             .background(Color(.systemGroupedBackground))
             .navigationTitle("マイページ")
             .navigationBarTitleDisplayMode(.inline)
+            .task { await viewModel.refreshAnnouncementUnreadCount() }
         }
     }
 
@@ -86,7 +87,7 @@ struct MyPageView: View {
             menuLinkRow(
                 symbol: "bell",
                 title: "お知らせ",
-                badge: "12",
+                badge: viewModel.announcementUnreadCount > 0 ? "\(viewModel.announcementUnreadCount)" : nil,
                 accentColor: .orange,
                 destination: AnyView(NotificationsView())
             )

--- a/ios/Rikako/Screen/MyPage/MyPageViewModel.swift
+++ b/ios/Rikako/Screen/MyPage/MyPageViewModel.swift
@@ -30,4 +30,28 @@ final class MyPageViewModel {
         .init(id: "school", title: "学校・塾向けの学習プランのご紹介"),
         .init(id: "recruit", title: "理科子を一緒に育てるメンバー募集中")
     ]
+
+    private(set) var announcementUnreadCount: Int = 0
+
+    private let fetchAnnouncements: FetchAnnouncementsUseCase
+    private let readStore: AnnouncementReadStore
+
+    init(
+        fetchAnnouncements: FetchAnnouncementsUseCase = AppContainer.shared.learningUseCases.fetchAnnouncements,
+        readStore: AnnouncementReadStore = AnnouncementReadStore()
+    ) {
+        self.fetchAnnouncements = fetchAnnouncements
+        self.readStore = readStore
+    }
+
+    func refreshAnnouncementUnreadCount() async {
+        do {
+            let fetched = try await fetchAnnouncements.execute()
+            announcementUnreadCount = fetched.filter { announcement in
+                announcement.isWithinUnreadWindow() && !readStore.isRead(id: announcement.id)
+            }.count
+        } catch {
+            announcementUnreadCount = 0
+        }
+    }
 }

--- a/ios/Rikako/Screen/Notifications/NotificationDetailView.swift
+++ b/ios/Rikako/Screen/Notifications/NotificationDetailView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct NotificationDetailView: View {
+    let announcement: Announcement
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 8) {
+                    categoryBadge
+                    Text(dateText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(announcement.title)
+                    .font(.title2.bold())
+
+                Divider()
+
+                Text(announcement.body)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(20)
+        }
+        .navigationTitle("お知らせ")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var categoryBadge: some View {
+        Text(NotificationCategoryStyle.label(for: announcement.category))
+            .font(.caption.bold())
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(NotificationCategoryStyle.color(for: announcement.category).opacity(0.15))
+            .foregroundStyle(NotificationCategoryStyle.color(for: announcement.category))
+            .clipShape(Capsule())
+    }
+
+    private var dateText: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy/MM/dd HH:mm"
+        return formatter.string(from: announcement.publishedAt)
+    }
+}
+
+enum NotificationCategoryStyle {
+    static func label(for category: String) -> String {
+        switch category {
+        case "release": return "リリース"
+        case "maintenance": return "メンテナンス"
+        case "info": return "お知らせ"
+        default: return category
+        }
+    }
+
+    static func color(for category: String) -> Color {
+        switch category {
+        case "release": return .green
+        case "maintenance": return .red
+        case "info": return .orange
+        default: return .gray
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        NotificationDetailView(
+            announcement: Announcement(
+                id: 1,
+                title: "新しい問題集を追加しました",
+                body: "基礎化学の復習に使いやすい問題集を追加しました。ぜひ使ってみてください。",
+                category: "release",
+                publishedAt: Date()
+            )
+        )
+    }
+}

--- a/ios/Rikako/Screen/Notifications/NotificationsViewModel.swift
+++ b/ios/Rikako/Screen/Notifications/NotificationsViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class NotificationsViewModel {
+    enum LoadState {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    private(set) var announcements: [Announcement] = []
+    private(set) var state: LoadState = .idle
+    private(set) var readIDs: Set<Int64> = []
+
+    private let fetchAnnouncements: FetchAnnouncementsUseCase
+    private let readStore: AnnouncementReadStore
+
+    init(
+        fetchAnnouncements: FetchAnnouncementsUseCase,
+        readStore: AnnouncementReadStore = AnnouncementReadStore()
+    ) {
+        self.fetchAnnouncements = fetchAnnouncements
+        self.readStore = readStore
+    }
+
+    var unreadCount: Int {
+        announcements.filter { isUnread($0) }.count
+    }
+
+    func isUnread(_ announcement: Announcement) -> Bool {
+        announcement.isWithinUnreadWindow() && !readIDs.contains(announcement.id)
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            let fetched = try await fetchAnnouncements.execute()
+            announcements = fetched
+            readStore.prune(existingIDs: Set(fetched.map { $0.id }))
+            readIDs = Set(fetched.map { $0.id }.filter { readStore.isRead(id: $0) })
+            state = .loaded
+        } catch {
+            state = .failed("お知らせの取得に失敗しました")
+        }
+    }
+
+    func markRead(_ announcement: Announcement) {
+        guard !readIDs.contains(announcement.id) else { return }
+        readStore.markRead(id: announcement.id)
+        readIDs.insert(announcement.id)
+    }
+}

--- a/ios/Rikako/Screen/NotificationsView.swift
+++ b/ios/Rikako/Screen/NotificationsView.swift
@@ -1,46 +1,112 @@
 import SwiftUI
 
 struct NotificationsView: View {
-    struct NotificationItem: Identifiable {
-        let id: Int
-        let title: String
-        let body: String
-        let date: String
-        let isUnread: Bool
-    }
-
-    private let notifications: [NotificationItem] = [
-        .init(id: 1, title: "春のチャレンジ応援キャンペーン", body: "期間限定で学習を続けやすい企画を実施中です。", date: "4/12", isUnread: true),
-        .init(id: 2, title: "新しい問題集を追加しました", body: "基礎化学の復習に使いやすい問題集を追加しました。", date: "4/10", isUnread: true),
-        .init(id: 3, title: "アップデートのお知らせ", body: "マイページと学習記録画面を改善しました。", date: "4/08", isUnread: false)
-    ]
+    @State private var viewModel = NotificationsViewModel(
+        fetchAnnouncements: AppContainer.shared.learningUseCases.fetchAnnouncements
+    )
 
     var body: some View {
-        List(notifications) { item in
-            HStack(alignment: .top, spacing: 12) {
-                Circle()
-                    .fill(item.isUnread ? Color.orange : Color(.systemGray4))
-                    .frame(width: 10, height: 10)
-                    .padding(.top, 6)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text(item.title)
-                            .font(.headline)
-                        Spacer()
-                        Text(item.date)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Text(item.body)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+        Group {
+            switch viewModel.state {
+            case .idle, .loading:
+                loadingView
+            case .failed(let message):
+                errorView(message: message)
+            case .loaded:
+                if viewModel.announcements.isEmpty {
+                    emptyView
+                } else {
+                    list
                 }
             }
-            .padding(.vertical, 6)
         }
         .navigationTitle("お知らせ")
         .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+        .refreshable { await viewModel.load() }
+    }
+
+    private var loadingView: some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text(message)
+                .foregroundStyle(.secondary)
+            Button("再読み込み") {
+                Task { await viewModel.load() }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "bell.slash")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("お知らせはありません")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var list: some View {
+        List(viewModel.announcements) { item in
+            NavigationLink {
+                NotificationDetailView(announcement: item)
+                    .onAppear { viewModel.markRead(item) }
+            } label: {
+                row(for: item)
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private func row(for item: Announcement) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Circle()
+                .fill(viewModel.isUnread(item) ? Color.orange : Color(.systemGray4))
+                .frame(width: 10, height: 10)
+                .padding(.top, 8)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(NotificationCategoryStyle.label(for: item.category))
+                        .font(.caption.bold())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(NotificationCategoryStyle.color(for: item.category).opacity(0.15))
+                        .foregroundStyle(NotificationCategoryStyle.color(for: item.category))
+                        .clipShape(Capsule())
+                    Spacer()
+                    Text(shortDate(item.publishedAt))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text(item.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(item.body)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func shortDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "M/d"
+        return formatter.string(from: date)
     }
 }
 

--- a/ios/Rikako/Screen/Settings/SettingsView.swift
+++ b/ios/Rikako/Screen/Settings/SettingsView.swift
@@ -64,6 +64,13 @@ struct SettingsView: View {
                         }
                     }
                 Divider().padding(.leading, 48)
+                NavigationLink {
+                    NotificationsView()
+                } label: {
+                    infoRow(symbol: "bell.fill", title: "お知らせ", accentColor: .orange)
+                }
+                .buttonStyle(.plain)
+                Divider().padding(.leading, 48)
                 infoRow(symbol: "questionmark.circle.fill", title: "使い方", accentColor: Color(.main))
                 Divider().padding(.leading, 48)
                 infoRow(symbol: "star.fill", title: "レビューする", accentColor: .orange)

--- a/ios/Rikako/Support/AnnouncementReadStore.swift
+++ b/ios/Rikako/Support/AnnouncementReadStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// お知らせの既読状態を UserDefaults で管理する。
+/// 「公開日から7日超過したものは自動的に既読扱い」のルールと組み合わせて未読を判定する。
+final class AnnouncementReadStore {
+    private let defaults: UserDefaults
+    private let key = "announcementReadIds"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    private var readIDs: Set<Int64> {
+        get {
+            let array = defaults.array(forKey: key) as? [NSNumber] ?? []
+            return Set(array.map { $0.int64Value })
+        }
+        set {
+            let array = newValue.map { NSNumber(value: $0) }
+            defaults.set(array, forKey: key)
+        }
+    }
+
+    func isRead(id: Int64) -> Bool {
+        readIDs.contains(id)
+    }
+
+    func markRead(id: Int64) {
+        var ids = readIDs
+        ids.insert(id)
+        readIDs = ids
+    }
+
+    /// 現在の announcement 一覧に存在しない ID を UserDefaults から削除する。
+    /// 7日ルールで未読対象にならない古いIDが溜まり続けるのを防ぐ。
+    func prune(existingIDs: Set<Int64>) {
+        readIDs = readIDs.intersection(existingIDs)
+    }
+}


### PR DESCRIPTION
## Summary
Issue #156 のステップ4: iOS にお知らせ機能を実装。

## 変更点
### データ層
- \`Announcement\` エンティティ追加
- \`AnnouncementListResponse\` 追加
- \`LearningRepository.fetchAnnouncements()\` → CDN \`v1/announcements.json\` から取得
- \`FetchAnnouncementsUseCase\` 追加

### 既読管理 (クライアント側のみ)
- \`AnnouncementReadStore\`: UserDefaults ベースの既読ID保存
- 未読判定: **公開日から7日以内 かつ 未タップ**
- 取得リストに無いID は起動時に prune してストア膨張を防止
- サーバ側・API には影響なし

### UI
- \`NotificationsView\` をモック実装から実データ版に差し替え
  - 空 / 読込中 / エラー / 一覧 の状態遷移
  - pull-to-refresh 対応
- \`NotificationDetailView\` 新規（タップで既読化）
- \`SettingsView\` の「アプリについて」に「お知らせ」行を追加（NavigationLink）

## Test plan
- [x] \`xcodebuild\` 成功（iphonesimulator）
- [ ] 実機・シミュレータで:
  - [ ] 設定 → お知らせ導線
  - [ ] 一覧表示（dev CDN に \`/publish\` 済みの場合）
  - [ ] 未読インジケータ（橙丸）がタップで消える
  - [ ] 7日経過した古いお知らせは自動的に既読扱い
  - [ ] 削除済みIDが UserDefaults から消える（prune）

## スコープ外
- Markdown レンダリング（現状はプレーンテキスト表示）
- プッシュ通知連携
- 公開日時の予約投稿

🤖 Generated with [Claude Code](https://claude.com/claude-code)