### PR TITLE
Chore: GitHub Actions を最新メジャーバージョンに更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/datasync-plan.yml
+++ b/.github/workflows/datasync-plan.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: app/go.mod
           cache-dependency-path: app/go.sum
@@ -29,7 +29,7 @@ jobs:
         run: go build -o datasync ./cmd/datasync
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ap-northeast-1
@@ -41,7 +41,7 @@ jobs:
           ./datasync -data ../data -env dev plan 2>&1 | tail -n +2 > ../datasync-plan.txt
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/deploy-admin-dev.yml
+++ b/.github/workflows/deploy-admin-dev.yml
@@ -22,10 +22,10 @@ jobs:
       image-tag: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-admin-frontend-dev.yml
+++ b/.github/workflows/deploy-admin-frontend-dev.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -41,7 +41,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,10 +22,10 @@ jobs:
       image-tag: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Run migrations
         run: |
@@ -70,7 +70,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 

--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Comment on PR with screenshots
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -36,16 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.14.0
           terraform_wrapper: false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -31,10 +31,10 @@ jobs:
         working-directory: ${{ matrix.working_directory }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.14"
           terraform_wrapper: false
@@ -43,7 +43,7 @@ jobs:
         uses: shmokmt/actions-setup-tfcmt@v2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ matrix.role_name }}
           aws-region: ap-northeast-1


### PR DESCRIPTION
## Summary
ワークフロー内で使われている GitHub Actions を最新メジャー版に統一更新。混在も解消。

| Action | Before | After |
|---|---|---|
| actions/checkout | v4, v5 (混在) | v6 |
| actions/cache | v4 | v5 |
| actions/setup-node | v4 | v6 |
| actions/setup-go | v5 | v6 |
| actions/github-script | v7, v8 (混在) | v9 |
| actions/upload-pages-artifact | v4 | v5 |
| aws-actions/configure-aws-credentials | v4 | v6 |
| hashicorp/setup-terraform | v3 | v4 |

最新済みでスキップ: setup-python v6 / upload-artifact v7 / deploy-pages v5 / amazon-ecr-login v2 / actions-setup-tfcmt v2

## 注意点
- v6 系 actions は **Node.js 24** ベース。GitHub-hosted runner は対応済みなので問題なし
- aws-actions/configure-aws-credentials v6 は OIDC 周りの API 変更なし
- マージ後、各ワークフローが正常に動くか観測（CI / deploy 系がそれぞれ次に走った時に確認）

## Test plan
- [x] yaml 構文上問題なし
- [ ] マージ後、最初に走る各ワークフロー（CI, deploy-dev, deploy-admin-frontend-dev など）が成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)