### PR TITLE
Fix: apply-terraform-dev.yml の actions を最新バージョンに揃える

### DIFF
--- a/.github/workflows/apply-terraform-dev.yml
+++ b/.github/workflows/apply-terraform-dev.yml
@@ -22,16 +22,16 @@ jobs:
         working-directory: terraform/environments/dev
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.14"
           terraform_wrapper: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
           aws-region: ap-northeast-1


### PR DESCRIPTION
## Summary
PR #164 で新規追加した \`apply-terraform-dev.yml\` だけ actions のバージョン更新（PR #165）から漏れていたため追従。

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| hashicorp/setup-terraform | v3 | v4 |
| aws-actions/configure-aws-credentials | v4 | v6 |

PR #164 マージ後の初回ワークフロー実行は成功したものの「Node.js 20 actions are deprecated」警告が出ていたので解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)