### PR TITLE
iOSビルド修正・prod環境設定・マイページUIクリーンアップ

### DIFF
--- a/ios/Configs/HighSchoolChemistryProd.xcconfig
+++ b/ios/Configs/HighSchoolChemistryProd.xcconfig
@@ -1,0 +1,5 @@
+APP_DISPLAY_NAME = Rikako Chemistry
+APP_SLUG = high-school-chemistry
+API_BASE_URL = https:/$()/api.rikako.jp
+CONTENT_BASE_URL = https:/$()/content.rikako.jp/v1
+PRODUCT_BUNDLE_IDENTIFIER = jp.conol.rikako

--- a/ios/Configs/HighSchoolChemistryStg.xcconfig
+++ b/ios/Configs/HighSchoolChemistryStg.xcconfig
@@ -1,5 +1,0 @@
-APP_DISPLAY_NAME = Rikako Chemistry Stg
-APP_SLUG = high-school-chemistry
-API_BASE_URL = https:/$()/api.stg.rikako.jp
-CONTENT_BASE_URL = https:/$()/content.stg.rikako.jp/v1
-PRODUCT_BUNDLE_IDENTIFIER = jp.conol.rikako.highschoolchemistry.stg

--- a/ios/Configs/ItPassportProd.xcconfig
+++ b/ios/Configs/ItPassportProd.xcconfig
@@ -1,0 +1,5 @@
+APP_DISPLAY_NAME = Rikako IT
+APP_SLUG = it-passport
+API_BASE_URL = https:/$()/api.rikako.jp
+CONTENT_BASE_URL = https:/$()/content.rikako.jp/v1
+PRODUCT_BUNDLE_IDENTIFIER = jp.conol.rikako.itpassport

--- a/ios/Configs/ItPassportStg.xcconfig
+++ b/ios/Configs/ItPassportStg.xcconfig
@@ -1,5 +1,0 @@
-APP_DISPLAY_NAME = Rikako IT Stg
-APP_SLUG = it-passport
-API_BASE_URL = https:/$()/api.stg.rikako.jp
-CONTENT_BASE_URL = https:/$()/content.stg.rikako.jp/v1
-PRODUCT_BUNDLE_IDENTIFIER = jp.conol.rikako.itpassport.stg

--- a/ios/Rikako.xcodeproj/project.pbxproj
+++ b/ios/Rikako.xcodeproj/project.pbxproj
@@ -28,9 +28,9 @@
 		17B40F6A2F65BCE4001A7DD8 /* RikakoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RikakoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		17B40F742F65BCE4001A7DD8 /* RikakoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RikakoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF0000000000000000000001 /* ItPassportDev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ItPassportDev.xcconfig; sourceTree = "<group>"; };
-		CF0000000000000000000002 /* ItPassportStg.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ItPassportStg.xcconfig; sourceTree = "<group>"; };
+		CF0000000000000000000002 /* ItPassportProd.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ItPassportProd.xcconfig; sourceTree = "<group>"; };
 		CF0000000000000000000003 /* HighSchoolChemistryDev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = HighSchoolChemistryDev.xcconfig; sourceTree = "<group>"; };
-		CF0000000000000000000004 /* HighSchoolChemistryStg.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = HighSchoolChemistryStg.xcconfig; sourceTree = "<group>"; };
+		CF0000000000000000000004 /* HighSchoolChemistryProd.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = HighSchoolChemistryProd.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -114,9 +114,9 @@
 			isa = PBXGroup;
 			children = (
 				CF0000000000000000000001 /* ItPassportDev.xcconfig */,
-				CF0000000000000000000002 /* ItPassportStg.xcconfig */,
+				CF0000000000000000000002 /* ItPassportProd.xcconfig */,
 				CF0000000000000000000003 /* HighSchoolChemistryDev.xcconfig */,
-				CF0000000000000000000004 /* HighSchoolChemistryStg.xcconfig */,
+				CF0000000000000000000004 /* HighSchoolChemistryProd.xcconfig */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -621,7 +621,7 @@
 			};
 			name = "ItPassportDev Debug";
 		};
-		CF0000000000000000000011 /* ItPassportStg Debug */ = {
+		CF0000000000000000000011 /* ItPassportProd Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -655,7 +655,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
-			name = "ItPassportStg Debug";
+			name = "ItPassportProd Debug";
 		};
 		CF0000000000000000000012 /* HighSchoolChemistryDev Debug */ = {
 			isa = XCBuildConfiguration;
@@ -693,7 +693,7 @@
 			};
 			name = "HighSchoolChemistryDev Debug";
 		};
-		CF0000000000000000000013 /* HighSchoolChemistryStg Debug */ = {
+		CF0000000000000000000013 /* HighSchoolChemistryProd Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -727,7 +727,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
-			name = "HighSchoolChemistryStg Debug";
+			name = "HighSchoolChemistryProd Debug";
 		};
 		CF0000000000000000000020 /* ItPassportDev Debug */ = {
 			isa = XCBuildConfiguration;
@@ -766,9 +766,9 @@
 			};
 			name = "ItPassportDev Debug";
 		};
-		CF0000000000000000000021 /* ItPassportStg Debug */ = {
+		CF0000000000000000000021 /* ItPassportProd Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CF0000000000000000000002 /* ItPassportStg.xcconfig */;
+			baseConfigurationReference = CF0000000000000000000002 /* ItPassportProd.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -801,7 +801,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = "ItPassportStg Debug";
+			name = "ItPassportProd Debug";
 		};
 		CF0000000000000000000022 /* HighSchoolChemistryDev Debug */ = {
 			isa = XCBuildConfiguration;
@@ -840,9 +840,9 @@
 			};
 			name = "HighSchoolChemistryDev Debug";
 		};
-		CF0000000000000000000023 /* HighSchoolChemistryStg Debug */ = {
+		CF0000000000000000000023 /* HighSchoolChemistryProd Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CF0000000000000000000004 /* HighSchoolChemistryStg.xcconfig */;
+			baseConfigurationReference = CF0000000000000000000004 /* HighSchoolChemistryProd.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -875,7 +875,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = "HighSchoolChemistryStg Debug";
+			name = "HighSchoolChemistryProd Debug";
 		};
 /* End XCBuildConfiguration section */
 
@@ -886,9 +886,9 @@
 				17B40F7C2F65BCE4001A7DD8 /* Debug */,
 				17B40F7D2F65BCE4001A7DD8 /* Release */,
 				CF0000000000000000000010 /* ItPassportDev Debug */,
-				CF0000000000000000000011 /* ItPassportStg Debug */,
+				CF0000000000000000000011 /* ItPassportProd Debug */,
 				CF0000000000000000000012 /* HighSchoolChemistryDev Debug */,
-				CF0000000000000000000013 /* HighSchoolChemistryStg Debug */,
+				CF0000000000000000000013 /* HighSchoolChemistryProd Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -899,9 +899,9 @@
 				17B40F7F2F65BCE4001A7DD8 /* Debug */,
 				17B40F802F65BCE4001A7DD8 /* Release */,
 				CF0000000000000000000020 /* ItPassportDev Debug */,
-				CF0000000000000000000021 /* ItPassportStg Debug */,
+				CF0000000000000000000021 /* ItPassportProd Debug */,
 				CF0000000000000000000022 /* HighSchoolChemistryDev Debug */,
-				CF0000000000000000000023 /* HighSchoolChemistryStg Debug */,
+				CF0000000000000000000023 /* HighSchoolChemistryProd Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Rikako.xcodeproj/xcshareddata/xcschemes/high-school-chemistry-dev.xcscheme
+++ b/ios/Rikako.xcodeproj/xcshareddata/xcschemes/high-school-chemistry-dev.xcscheme
@@ -66,4 +66,3 @@
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>
-

--- a/ios/Rikako.xcodeproj/xcshareddata/xcschemes/high-school-chemistry-prod.xcscheme
+++ b/ios/Rikako.xcodeproj/xcshareddata/xcschemes/high-school-chemistry-prod.xcscheme
@@ -31,7 +31,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "HighSchoolChemistryStg Debug"
+      buildConfiguration = "HighSchoolChemistryProd Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,18 +52,17 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "HighSchoolChemistryStg Debug"
+      buildConfiguration = "HighSchoolChemistryProd Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "HighSchoolChemistryStg Debug">
+      buildConfiguration = "HighSchoolChemistryProd Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "HighSchoolChemistryStg Debug"
+      buildConfiguration = "HighSchoolChemistryProd Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>
-

--- a/ios/Rikako.xcodeproj/xcshareddata/xcschemes/it-passport-dev.xcscheme
+++ b/ios/Rikako.xcodeproj/xcshareddata/xcschemes/it-passport-dev.xcscheme
@@ -66,4 +66,3 @@
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>
-

--- a/ios/Rikako.xcodeproj/xcshareddata/xcschemes/it-passport-prod.xcscheme
+++ b/ios/Rikako.xcodeproj/xcshareddata/xcschemes/it-passport-prod.xcscheme
@@ -31,7 +31,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "ItPassportStg Debug"
+      buildConfiguration = "ItPassportProd Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,18 +52,17 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "ItPassportStg Debug"
+      buildConfiguration = "ItPassportProd Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "ItPassportStg Debug">
+      buildConfiguration = "ItPassportProd Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "ItPassportStg Debug"
+      buildConfiguration = "ItPassportProd Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>
-

--- a/ios/Rikako/Info.plist
+++ b/ios/Rikako/Info.plist
@@ -4,6 +4,20 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>$(APP_DISPLAY_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>RIKAKO_API_BASE_URL</key>
 	<string>$(API_BASE_URL)</string>
 	<key>RIKAKO_APP_SLUG</key>

--- a/ios/Rikako/Screen/MyPage/MyPageView.swift
+++ b/ios/Rikako/Screen/MyPage/MyPageView.swift
@@ -9,10 +9,7 @@ struct MyPageView: View {
             ScrollView {
                 VStack(spacing: 18) {
                     profileCard
-                    shortcutButtons
                     menuList
-                    promoRow
-                    footerTexts
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
@@ -67,14 +64,6 @@ struct MyPageView: View {
         .buttonStyle(.plain)
     }
 
-    private var shortcutButtons: some View {
-        HStack(spacing: 12) {
-            ForEach(viewModel.shortcutItems) { item in
-                shortcutButton(title: item.title, symbol: item.symbol, accentColor: item.color)
-            }
-        }
-    }
-
     private var menuList: some View {
         VStack(spacing: 0) {
             menuLinkRow(
@@ -107,53 +96,6 @@ struct MyPageView: View {
         )
     }
 
-    private var promoRow: some View {
-        HStack(spacing: 10) {
-            promoCard(
-                title: "今日のおすすめ\n10問学習を続けよう",
-                subtitle: "学習タブへ",
-                color: Color(.main).opacity(0.16)
-            )
-            promoCard(
-                title: "理科子をもっと\n使いやすくする",
-                subtitle: "お知らせを見る",
-                color: Color.orange.opacity(0.12)
-            )
-        }
-    }
-
-    private var footerTexts: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            ForEach(viewModel.footerItems) { item in
-                Text(item.title)
-            }
-        }
-        .font(.footnote)
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func shortcutButton(title: String, symbol: String, accentColor: Color) -> some View {
-        Button {} label: {
-            HStack(spacing: 8) {
-                Image(systemName: symbol)
-                    .foregroundStyle(accentColor)
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-            }
-            .foregroundStyle(.primary)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-            .background(
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(Color.white)
-                    .shadow(color: Color.black.opacity(0.04), radius: 10, x: 0, y: 4)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-        }
-        .buttonStyle(.plain)
-    }
-
     private func menuLinkRow(symbol: String, title: String, badge: String? = nil, accentColor: Color, destination: AnyView) -> some View {
         NavigationLink(destination: destination) {
             HStack(spacing: 14) {
@@ -184,25 +126,7 @@ struct MyPageView: View {
         }
     }
 
-    private func promoCard(title: String, subtitle: String, color: Color) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(title)
-                .font(.headline.bold())
-                .foregroundStyle(.primary)
-            Spacer()
-            Text(subtitle)
-                .font(.caption.bold())
-                .foregroundStyle(Color(.main))
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, minHeight: 120, alignment: .leading)
-        .background(color)
-        .clipShape(RoundedRectangle(cornerRadius: 18))
-        .overlay(
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(Color.white.opacity(0.6), lineWidth: 1)
-        )
-    }
+
 }
 
 #Preview {

--- a/ios/Rikako/Screen/MyPage/MyPageViewModel.swift
+++ b/ios/Rikako/Screen/MyPage/MyPageViewModel.swift
@@ -1,47 +1,20 @@
 import Foundation
 import Observation
-import SwiftUI
 
 @Observable
 @MainActor
 final class MyPageViewModel {
-    struct ShortcutItem: Identifiable {
-        let id: String
-        let title: String
-        let symbol: String
-        let colorHexName: String
-
-        var color: Color {
-            Color(colorHexName)
-        }
-    }
-
-    struct FooterItem: Identifiable {
-        let id: String
-        let title: String
-    }
-
-    let shortcutItems: [ShortcutItem] = [
-        .init(id: "exam", title: "実力テスト", symbol: "trophy", colorHexName: "main"),
-        .init(id: "ranking", title: "ランキング", symbol: "crown", colorHexName: "correctPink")
-    ]
-
-    let footerItems: [FooterItem] = [
-        .init(id: "school", title: "学校・塾向けの学習プランのご紹介"),
-        .init(id: "recruit", title: "理科子を一緒に育てるメンバー募集中")
-    ]
-
     private(set) var announcementUnreadCount: Int = 0
 
     private let fetchAnnouncements: FetchAnnouncementsUseCase
     private let readStore: AnnouncementReadStore
 
     init(
-        fetchAnnouncements: FetchAnnouncementsUseCase = AppContainer.shared.learningUseCases.fetchAnnouncements,
-        readStore: AnnouncementReadStore = AnnouncementReadStore()
+        fetchAnnouncements: FetchAnnouncementsUseCase? = nil,
+        readStore: AnnouncementReadStore? = nil
     ) {
-        self.fetchAnnouncements = fetchAnnouncements
-        self.readStore = readStore
+        self.fetchAnnouncements = fetchAnnouncements ?? AppContainer.shared.learningUseCases.fetchAnnouncements
+        self.readStore = readStore ?? AnnouncementReadStore()
     }
 
     func refreshAnnouncementUnreadCount() async {

--- a/ios/Rikako/Screen/Notifications/NotificationsViewModel.swift
+++ b/ios/Rikako/Screen/Notifications/NotificationsViewModel.swift
@@ -20,10 +20,10 @@ final class NotificationsViewModel {
 
     init(
         fetchAnnouncements: FetchAnnouncementsUseCase,
-        readStore: AnnouncementReadStore = AnnouncementReadStore()
+        readStore: AnnouncementReadStore? = nil
     ) {
         self.fetchAnnouncements = fetchAnnouncements
-        self.readStore = readStore
+        self.readStore = readStore ?? AnnouncementReadStore()
     }
 
     var unreadCount: Int {


### PR DESCRIPTION
## Summary
- Info.plist に必要なキーを追加し、iOS実機ビルドエラーを修正
- xcconfig・スキーム・ビルド設定の stg → prod リネーム、Bundle ID 設定
- マイページから不要なUI要素（ショートカット・プロモ・フッター）を削除
- `MyPageViewModel` / `NotificationsViewModel` の Swift 並行性警告を修正

## Test plan
- [x] `high-school-chemistry-dev` スキームで実機ビルド・インストールが成功すること
- [x] `high-school-chemistry-prod` スキームでビルドが通ること
- [x] マイページに実力テスト・ランキング・プロモ・フッターが表示されないこと

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)