### PR TITLE
iOSにQRコードデータ引き継ぎ機能を追加

### DIFF
--- a/app/internal/db/querier.go
+++ b/app/internal/db/querier.go
@@ -64,6 +64,7 @@ type Querier interface {
 	GetImageURLsByQuestionIDs(ctx context.Context, dollar_1 []int64) ([]GetImageURLsByQuestionIDsRow, error)
 	GetQuestionByID(ctx context.Context, id int64) (GetQuestionByIDRow, error)
 	GetSingleChoiceID(ctx context.Context, questionID int64) (int64, error)
+	GetTransferTokenIdentityID(ctx context.Context, token string) (string, error)
 	GetUserAppSetting(ctx context.Context, arg GetUserAppSettingParams) (GetUserAppSettingRow, error)
 	GetUserByIdentityID(ctx context.Context, identityID string) (int64, error)
 	GetUserProfile(ctx context.Context, id int64) (GetUserProfileRow, error)

--- a/app/internal/db/transfer.sql.go
+++ b/app/internal/db/transfer.sql.go
@@ -79,3 +79,17 @@ func (q *Queries) GetActiveTransferToken(ctx context.Context, identityID string)
 	err := row.Scan(&i.Token, &i.ExpiresAt)
 	return i, err
 }
+
+const getTransferTokenIdentityID = `-- name: GetTransferTokenIdentityID :one
+SELECT identity_id FROM transfer_tokens
+WHERE token = $1
+  AND used_at IS NULL
+  AND expires_at > CURRENT_TIMESTAMP
+`
+
+func (q *Queries) GetTransferTokenIdentityID(ctx context.Context, token string) (string, error) {
+	row := q.db.QueryRowContext(ctx, getTransferTokenIdentityID, token)
+	var identity_id string
+	err := row.Scan(&identity_id)
+	return identity_id, err
+}

--- a/app/internal/handler/transfer.go
+++ b/app/internal/handler/transfer.go
@@ -64,6 +64,15 @@ func (h *Handler) ApplyTransferToken(ctx context.Context, request api.ApplyTrans
 		return api.ApplyTransferToken400JSONResponse{Code: "INVALID_PARAMETER", Message: "token is required"}, nil
 	}
 
+	// トークンの発行元 identity を確認（消費前にチェック）
+	sourceIdentityID, err := h.queries.GetTransferTokenIdentityID(ctx, request.Body.Token)
+	if err != nil {
+		return api.ApplyTransferToken400JSONResponse{Code: "INVALID_TOKEN", Message: "token is invalid or expired"}, nil
+	}
+	if sourceIdentityID == request.Params.XDeviceID {
+		return api.ApplyTransferToken400JSONResponse{Code: "SAME_DEVICE", Message: "cannot apply token issued by the same device"}, nil
+	}
+
 	identityID, err := h.queries.ConsumeTransferToken(ctx, request.Body.Token)
 	if err != nil {
 		return api.ApplyTransferToken400JSONResponse{Code: "INVALID_TOKEN", Message: "token is invalid or expired"}, nil

--- a/app/sql/queries/transfer.sql
+++ b/app/sql/queries/transfer.sql
@@ -14,6 +14,12 @@ INSERT INTO transfer_tokens (token, identity_id, expires_at)
 VALUES ($1, $2, $3)
 RETURNING token, expires_at;
 
+-- name: GetTransferTokenIdentityID :one
+SELECT identity_id FROM transfer_tokens
+WHERE token = $1
+  AND used_at IS NULL
+  AND expires_at > CURRENT_TIMESTAMP;
+
 -- name: ConsumeTransferToken :one
 UPDATE transfer_tokens
 SET used_at = CURRENT_TIMESTAMP

--- a/ios/Configs/HighSchoolChemistryDev.xcconfig
+++ b/ios/Configs/HighSchoolChemistryDev.xcconfig
@@ -1,4 +1,4 @@
-APP_DISPLAY_NAME = Rikako Chemistry Dev
+APP_DISPLAY_NAME = 4択化学（Dev）
 APP_SLUG = high-school-chemistry
 API_BASE_URL = https:/$()/api.dev.rikako.jp
 CONTENT_BASE_URL = https:/$()/content.dev.rikako.jp/v1

--- a/ios/Configs/HighSchoolChemistryProd.xcconfig
+++ b/ios/Configs/HighSchoolChemistryProd.xcconfig
@@ -1,4 +1,4 @@
-APP_DISPLAY_NAME = Rikako Chemistry
+APP_DISPLAY_NAME = 4択化学
 APP_SLUG = high-school-chemistry
 API_BASE_URL = https:/$()/api.rikako.jp
 CONTENT_BASE_URL = https:/$()/content.rikako.jp/v1

--- a/ios/Rikako.xcodeproj/project.pbxproj
+++ b/ios/Rikako.xcodeproj/project.pbxproj
@@ -298,6 +298,62 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		177B9F902FA428E000678E20 /* ItPassportDev Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoTests;
+			};
+			name = "ItPassportDev Debug";
+		};
+		177B9F912FA428E000678E20 /* ItPassportProd Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoTests;
+			};
+			name = "ItPassportProd Debug";
+		};
+		177B9F922FA428E000678E20 /* HighSchoolChemistryDev Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoTests;
+			};
+			name = "HighSchoolChemistryDev Debug";
+		};
+		177B9F932FA428E000678E20 /* HighSchoolChemistryProd Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoTests;
+			};
+			name = "HighSchoolChemistryProd Debug";
+		};
+		177B9F942FA428E000678E20 /* ItPassportDev Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoUITests;
+			};
+			name = "ItPassportDev Debug";
+		};
+		177B9F952FA428E000678E20 /* ItPassportProd Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoUITests;
+			};
+			name = "ItPassportProd Debug";
+		};
+		177B9F962FA428E000678E20 /* HighSchoolChemistryDev Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoUITests;
+			};
+			name = "HighSchoolChemistryDev Debug";
+		};
+		177B9F972FA428E000678E20 /* HighSchoolChemistryProd Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = RikakoUITests;
+			};
+			name = "HighSchoolChemistryProd Debug";
+		};
 		17B40F7C2F65BCE4001A7DD8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -422,11 +478,11 @@
 		17B40F7F2F65BCE4001A7DD8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				API_BASE_URL = "https://api.dev.rikako.jp";
 				APP_DISPLAY_NAME = Rikako;
 				APP_SLUG = "high-school-chemistry";
-				API_BASE_URL = "https://api.dev.rikako.jp";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CONTENT_BASE_URL = "https://content.dev.rikako.jp/v1";
 				CURRENT_PROJECT_VERSION = 1;
@@ -434,13 +490,13 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Rikako/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Rikako;
 				INFOPLIST_KEY_RIKAKO_API_BASE_URL = "https://api.dev.rikako.jp";
 				INFOPLIST_KEY_RIKAKO_APP_SLUG = "high-school-chemistry";
 				INFOPLIST_KEY_RIKAKO_CONTENT_BASE_URL = "https://content.dev.rikako.jp/v1";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -463,11 +519,11 @@
 		17B40F802F65BCE4001A7DD8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				API_BASE_URL = "https://api.dev.rikako.jp";
 				APP_DISPLAY_NAME = Rikako;
 				APP_SLUG = "high-school-chemistry";
-				API_BASE_URL = "https://api.dev.rikako.jp";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CONTENT_BASE_URL = "https://content.dev.rikako.jp/v1";
 				CURRENT_PROJECT_VERSION = 1;
@@ -475,13 +531,13 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Rikako/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Rikako;
 				INFOPLIST_KEY_RIKAKO_API_BASE_URL = "https://api.dev.rikako.jp";
 				INFOPLIST_KEY_RIKAKO_APP_SLUG = "high-school-chemistry";
 				INFOPLIST_KEY_RIKAKO_CONTENT_BASE_URL = "https://content.dev.rikako.jp/v1";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -911,6 +967,10 @@
 			buildConfigurations = (
 				17B40F822F65BCE4001A7DD8 /* Debug */,
 				17B40F832F65BCE4001A7DD8 /* Release */,
+				177B9F902FA428E000678E20 /* ItPassportDev Debug */,
+				177B9F912FA428E000678E20 /* ItPassportProd Debug */,
+				177B9F922FA428E000678E20 /* HighSchoolChemistryDev Debug */,
+				177B9F932FA428E000678E20 /* HighSchoolChemistryProd Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -920,6 +980,10 @@
 			buildConfigurations = (
 				17B40F852F65BCE4001A7DD8 /* Debug */,
 				17B40F862F65BCE4001A7DD8 /* Release */,
+				177B9F942FA428E000678E20 /* ItPassportDev Debug */,
+				177B9F952FA428E000678E20 /* ItPassportProd Debug */,
+				177B9F962FA428E000678E20 /* HighSchoolChemistryDev Debug */,
+				177B9F972FA428E000678E20 /* HighSchoolChemistryProd Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Rikako/AppContainer.swift
+++ b/ios/Rikako/AppContainer.swift
@@ -5,6 +5,7 @@ final class AppContainer {
 
     let appState: AppState
     let learningUseCases: LearningUseCases
+    let deviceIdentityProvider: DeviceIdentityProviding
     let anonymousSignIn: () async throws -> String
 
     private init() {
@@ -22,6 +23,7 @@ final class AppContainer {
 
         self.appState = AppState.shared
         self.learningUseCases = LearningUseCases(repository: repository)
+        self.deviceIdentityProvider = deviceIdentityProvider
         self.anonymousSignIn = { try await repository.anonymousSignIn() }
     }
 }

--- a/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
+++ b/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
@@ -193,9 +193,12 @@ final class RemoteLearningRepository: LearningRepository {
         let (data, response) = try await httpClient.data(for: request)
         try validateResponse(response)
 
-        struct Response: Decodable { let token: String; let expiresAt: Date }
+        struct Response: Decodable {
+            let token: String
+            let expires_at: Date
+        }
         let result = try decoder.decode(Response.self, from: data)
-        return TransferToken(token: result.token, expiresAt: result.expiresAt)
+        return TransferToken(token: result.token, expiresAt: result.expires_at)
     }
 
     func refreshTransferToken() async throws -> TransferToken {
@@ -208,9 +211,12 @@ final class RemoteLearningRepository: LearningRepository {
         let (data, response) = try await httpClient.data(for: request)
         try validateResponse(response)
 
-        struct Response: Decodable { let token: String; let expiresAt: Date }
+        struct Response: Decodable {
+            let token: String
+            let expires_at: Date
+        }
         let result = try decoder.decode(Response.self, from: data)
-        return TransferToken(token: result.token, expiresAt: result.expiresAt)
+        return TransferToken(token: result.token, expiresAt: result.expires_at)
     }
 
     func applyTransferToken(_ token: String) async throws -> String {
@@ -227,9 +233,9 @@ final class RemoteLearningRepository: LearningRepository {
         let (data, response) = try await httpClient.data(for: request)
         try validateResponse(response)
 
-        struct Response: Decodable { let identityId: String }
+        struct Response: Decodable { let identity_id: String }
         let result = try decoder.decode(Response.self, from: data)
-        return result.identityId
+        return result.identity_id
     }
 
     private func validateResponse(_ response: URLResponse) throws {

--- a/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
+++ b/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
@@ -231,7 +231,13 @@ final class RemoteLearningRepository: LearningRepository {
         request.httpBody = try encoder.encode(Body(token: token))
 
         let (data, response) = try await httpClient.data(for: request)
-        try validateResponse(response)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            struct ErrorResponse: Decodable { let code: String }
+            if let body = try? decoder.decode(ErrorResponse.self, from: data), body.code == "SAME_DEVICE" {
+                throw APIError.sameDevice
+            }
+            throw APIError.httpError(http.statusCode)
+        }
 
         struct Response: Decodable { let identity_id: String }
         let result = try decoder.decode(Response.self, from: data)

--- a/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
+++ b/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
@@ -184,6 +184,54 @@ final class RemoteLearningRepository: LearningRepository {
         return try decoder.decode(T.self, from: data)
     }
 
+    func fetchTransferToken() async throws -> TransferToken {
+        let url = apiBaseURL.appendingPathComponent("transfer/token")
+        var request = URLRequest(url: url)
+        let deviceId = try await deviceIdentityProvider.getIdentityId()
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-ID")
+
+        let (data, response) = try await httpClient.data(for: request)
+        try validateResponse(response)
+
+        struct Response: Decodable { let token: String; let expiresAt: Date }
+        let result = try decoder.decode(Response.self, from: data)
+        return TransferToken(token: result.token, expiresAt: result.expiresAt)
+    }
+
+    func refreshTransferToken() async throws -> TransferToken {
+        let url = apiBaseURL.appendingPathComponent("transfer/token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let deviceId = try await deviceIdentityProvider.getIdentityId()
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-ID")
+
+        let (data, response) = try await httpClient.data(for: request)
+        try validateResponse(response)
+
+        struct Response: Decodable { let token: String; let expiresAt: Date }
+        let result = try decoder.decode(Response.self, from: data)
+        return TransferToken(token: result.token, expiresAt: result.expiresAt)
+    }
+
+    func applyTransferToken(_ token: String) async throws -> String {
+        let url = apiBaseURL.appendingPathComponent("transfer/apply")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let deviceId = try await deviceIdentityProvider.getIdentityId()
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-ID")
+
+        struct Body: Encodable { let token: String }
+        request.httpBody = try encoder.encode(Body(token: token))
+
+        let (data, response) = try await httpClient.data(for: request)
+        try validateResponse(response)
+
+        struct Response: Decodable { let identityId: String }
+        let result = try decoder.decode(Response.self, from: data)
+        return result.identityId
+    }
+
     private func validateResponse(_ response: URLResponse) throws {
         guard let http = response as? HTTPURLResponse else {
             throw APIError.invalidResponse

--- a/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
+++ b/ios/Rikako/Data/Repository/RemoteLearningRepository.swift
@@ -232,8 +232,7 @@ final class RemoteLearningRepository: LearningRepository {
 
         let (data, response) = try await httpClient.data(for: request)
         if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-            struct ErrorResponse: Decodable { let code: String }
-            if let body = try? decoder.decode(ErrorResponse.self, from: data), body.code == "SAME_DEVICE" {
+            if (String(data: data, encoding: .utf8) ?? "").contains("SAME_DEVICE") {
                 throw APIError.sameDevice
             }
             throw APIError.httpError(http.statusCode)

--- a/ios/Rikako/Domain/Repository/LearningRepository.swift
+++ b/ios/Rikako/Domain/Repository/LearningRepository.swift
@@ -27,4 +27,12 @@ protocol LearningRepository {
     func fetchUserProfile(appSlug: String) async throws -> UserProfile
     func updateUserProfile(appSlug: String, request: UpdateUserProfileRequest) async throws -> UserProfile
     func fetchAnnouncements() async throws -> [Announcement]
+    func fetchTransferToken() async throws -> TransferToken
+    func refreshTransferToken() async throws -> TransferToken
+    func applyTransferToken(_ token: String) async throws -> String
+}
+
+struct TransferToken {
+    let token: String
+    let expiresAt: Date
 }

--- a/ios/Rikako/Domain/UseCase/LearningUseCases.swift
+++ b/ios/Rikako/Domain/UseCase/LearningUseCases.swift
@@ -14,6 +14,9 @@ struct LearningUseCases {
     let fetchUserProfile: FetchUserProfileUseCase
     let updateUserProfile: UpdateUserProfileUseCase
     let fetchAnnouncements: FetchAnnouncementsUseCase
+    let fetchTransferToken: FetchTransferTokenUseCase
+    let refreshTransferToken: RefreshTransferTokenUseCase
+    let applyTransferToken: ApplyTransferTokenUseCase
 
     init(repository: LearningRepository) {
         self.fetchAppStatus = FetchAppStatusUseCase(repository: repository)
@@ -29,6 +32,33 @@ struct LearningUseCases {
         self.fetchUserProfile = FetchUserProfileUseCase(repository: repository)
         self.updateUserProfile = UpdateUserProfileUseCase(repository: repository)
         self.fetchAnnouncements = FetchAnnouncementsUseCase(repository: repository)
+        self.fetchTransferToken = FetchTransferTokenUseCase(repository: repository)
+        self.refreshTransferToken = RefreshTransferTokenUseCase(repository: repository)
+        self.applyTransferToken = ApplyTransferTokenUseCase(repository: repository)
+    }
+}
+
+struct FetchTransferTokenUseCase {
+    private let repository: LearningRepository
+    init(repository: LearningRepository) { self.repository = repository }
+    func execute() async throws -> TransferToken {
+        try await repository.fetchTransferToken()
+    }
+}
+
+struct RefreshTransferTokenUseCase {
+    private let repository: LearningRepository
+    init(repository: LearningRepository) { self.repository = repository }
+    func execute() async throws -> TransferToken {
+        try await repository.refreshTransferToken()
+    }
+}
+
+struct ApplyTransferTokenUseCase {
+    private let repository: LearningRepository
+    init(repository: LearningRepository) { self.repository = repository }
+    func execute(token: String) async throws -> String {
+        try await repository.applyTransferToken(token)
     }
 }
 

--- a/ios/Rikako/Info.plist
+++ b/ios/Rikako/Info.plist
@@ -24,6 +24,10 @@
 	<string>$(APP_SLUG)</string>
 	<key>RIKAKO_CONTENT_BASE_URL</key>
 	<string>$(CONTENT_BASE_URL)</string>
+	<key>NSCameraUsageDescription</key>
+	<string>QRコードを読み取るためにカメラを使用します</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>引き継ぎQRコードを写真アプリに保存します</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/ios/Rikako/Infrastructure/Identity/DeviceIdentityProvider.swift
+++ b/ios/Rikako/Infrastructure/Identity/DeviceIdentityProvider.swift
@@ -3,6 +3,7 @@ import Security
 
 protocol DeviceIdentityProviding {
     func getIdentityId() async throws -> String
+    func overrideIdentityId(_ id: String)
 }
 
 final class CognitoDeviceIdentityProvider: DeviceIdentityProviding {
@@ -28,6 +29,11 @@ final class CognitoDeviceIdentityProvider: DeviceIdentityProviding {
         keychainStore.save(identityId)
         cachedIdentityId = identityId
         return identityId
+    }
+
+    func overrideIdentityId(_ id: String) {
+        keychainStore.save(id)
+        cachedIdentityId = id
     }
 
     private func fetchIdentityId() async throws -> String {

--- a/ios/Rikako/Infrastructure/Network/HTTPClient.swift
+++ b/ios/Rikako/Infrastructure/Network/HTTPClient.swift
@@ -20,6 +20,7 @@ struct URLSessionHTTPClient: HTTPClient {
 enum APIError: LocalizedError {
     case invalidResponse
     case httpError(Int)
+    case sameDevice
 
     var errorDescription: String? {
         switch self {
@@ -27,6 +28,8 @@ enum APIError: LocalizedError {
             return "サーバーからの応答が不正です"
         case .httpError(let code):
             return "サーバーエラー (HTTP \(code))"
+        case .sameDevice:
+            return "自分のデバイスのQRコードは使用できません"
         }
     }
 }

--- a/ios/Rikako/Preview/PreviewLearningRepository.swift
+++ b/ios/Rikako/Preview/PreviewLearningRepository.swift
@@ -159,6 +159,24 @@ final class PreviewLearningRepository: LearningRepository {
     }
 }
 
+extension PreviewLearningRepository {
+    func fetchTransferToken() async throws -> TransferToken {
+        TransferToken(token: "preview-token-abcdef1234567890", expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600))
+    }
+    func refreshTransferToken() async throws -> TransferToken {
+        TransferToken(token: "preview-token-new-\(UUID().uuidString.prefix(8))", expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600))
+    }
+    func applyTransferToken(_ token: String) async throws -> String {
+        "preview-identity-id-from-transfer"
+    }
+}
+
+final class PreviewDeviceIdentityProvider: DeviceIdentityProviding {
+    private(set) var identityId = "preview-identity-id"
+    func getIdentityId() async throws -> String { identityId }
+    func overrideIdentityId(_ id: String) { identityId = id }
+}
+
 enum PreviewAppContainer {
     private static let learningUseCases = LearningUseCases(repository: PreviewLearningRepository())
 

--- a/ios/Rikako/Screen/ProfileView.swift
+++ b/ios/Rikako/Screen/ProfileView.swift
@@ -43,6 +43,21 @@ struct ProfileView: View {
                 }
             }
 
+            Section("データ管理") {
+                NavigationLink {
+                    TransferView(
+                        viewModel: TransferViewModel(
+                            fetchTokenUseCase: AppContainer.shared.learningUseCases.fetchTransferToken,
+                            refreshTokenUseCase: AppContainer.shared.learningUseCases.refreshTransferToken,
+                            applyTokenUseCase: AppContainer.shared.learningUseCases.applyTransferToken,
+                            deviceIdentityProvider: AppContainer.shared.deviceIdentityProvider
+                        )
+                    )
+                } label: {
+                    Label("データ引き継ぎ", systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+
             Section("学習記録") {
                 HStack {
                     Label("総解答数", systemImage: "number")

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -252,7 +252,7 @@ private func generateQRCode(from string: String) -> UIImage? {
 private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date) -> UIImage {
     let w: CGFloat = 800
     let h: CGFloat = 1000
-    let accentColor = UIColor(named: "AccentColor") ?? .systemBlue
+    let accentColor = UIColor(named: "main") ?? .systemGreen
 
     let renderer = UIGraphicsImageRenderer(size: CGSize(width: w, height: h))
     return renderer.image { ctx in

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -392,13 +392,12 @@ private final class ScannerViewController: UIViewController, AVCaptureMetadataOu
     }
 }
 
-#Preview("保存カード") {
+#Preview("保存カード", traits: .fixedLayout(width: 400, height: 500)) {
     let qr = generateQRCode(from: "preview-token-abcdef1234567890") ?? UIImage()
     let card = makeTransferCardImage(qrSource: qr, expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600))
     Image(uiImage: card)
         .resizable()
         .scaledToFit()
-        .padding()
 }
 
 #Preview {

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -81,7 +81,7 @@ private struct IssueTokenView: View {
                         .padding(.horizontal)
 
                     Button {
-                        Task { await saveQRToPhotos(makeTransferCardImage(qrSource: qrImage, expiresAt: token.expiresAt, identityId: viewModel.deviceIdentityId)) }
+                        Task { await saveQRToPhotos(makeTransferCardImage(qrSource: qrImage, expiresAt: token.expiresAt, userId: AppState.shared.userId)) }
                     } label: {
                         Label("写真に保存", systemImage: "photo.badge.plus")
                             .font(.subheadline)
@@ -249,7 +249,7 @@ private func generateQRCode(from string: String) -> UIImage? {
     return UIImage(cgImage: cgImage)
 }
 
-private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date, identityId: String?) -> UIImage {
+private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date, userId: Int64?) -> UIImage {
     let w: CGFloat = 800
     let h: CGFloat = 1060
     let accentColor = UIColor(named: "main") ?? .systemGreen
@@ -315,15 +315,12 @@ private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date, identityI
         let expiresSize = expiresStr.size(withAttributes: expiresAttrs)
         expiresStr.draw(at: CGPoint(x: (w - expiresSize.width) / 2, y: footerY), withAttributes: expiresAttrs)
 
-        if let id = identityId {
-            let masked = id.count > 14
-                ? "\(id.prefix(6))...\(id.suffix(6))"
-                : id
+        if let uid = userId {
             let idAttrs: [NSAttributedString.Key: Any] = [
-                .font: UIFont.monospacedSystemFont(ofSize: 18, weight: .regular),
+                .font: UIFont.monospacedDigitSystemFont(ofSize: 20, weight: .regular),
                 .foregroundColor: UIColor(white: 0.5, alpha: 1)
             ]
-            let idStr = "ユーザーID: \(masked)" as NSString
+            let idStr = "ユーザーID: \(uid)" as NSString
             let idSize = idStr.size(withAttributes: idAttrs)
             idStr.draw(at: CGPoint(x: (w - idSize.width) / 2, y: footerY + 34), withAttributes: idAttrs)
         }
@@ -407,7 +404,7 @@ private final class ScannerViewController: UIViewController, AVCaptureMetadataOu
 
 #Preview("保存カード", traits: .fixedLayout(width: 400, height: 500)) {
     let qr = generateQRCode(from: "preview-token-abcdef1234567890") ?? UIImage()
-    let card = makeTransferCardImage(qrSource: qr, expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600), identityId: "ap-northeast-1:51acc74e-ec8d-4de4-bfa1-84648ea45222")
+    let card = makeTransferCardImage(qrSource: qr, expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600), userId: 12345)
     Image(uiImage: card)
         .resizable()
         .scaledToFit()

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -81,7 +81,7 @@ private struct IssueTokenView: View {
                         .padding(.horizontal)
 
                     Button {
-                        Task { await saveQRToPhotos(scaledQRCode(qrImage)) }
+                        Task { await saveQRToPhotos(makeTransferCardImage(qrSource: qrImage, expiresAt: token.expiresAt)) }
                     } label: {
                         Label("写真に保存", systemImage: "photo.badge.plus")
                             .font(.subheadline)
@@ -249,11 +249,79 @@ private func generateQRCode(from string: String) -> UIImage? {
     return UIImage(cgImage: cgImage)
 }
 
-private func scaledQRCode(_ source: UIImage, size: CGFloat = 1024) -> UIImage {
-    let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date) -> UIImage {
+    let w: CGFloat = 800
+    let h: CGFloat = 1000
+    let accentColor = UIColor(named: "AccentColor") ?? .systemBlue
+
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: w, height: h))
     return renderer.image { ctx in
-        ctx.cgContext.interpolationQuality = .none
-        source.draw(in: CGRect(origin: .zero, size: CGSize(width: size, height: size)))
+        let cg = ctx.cgContext
+
+        // 白背景
+        UIColor.white.setFill()
+        UIRectFill(CGRect(x: 0, y: 0, width: w, height: h))
+
+        // ── ヘッダー ─────────────────────────────────
+        let headerH: CGFloat = 190
+        accentColor.setFill()
+        UIRectFill(CGRect(x: 0, y: 0, width: w, height: headerH))
+
+        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Rikako"
+        let nameAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.boldSystemFont(ofSize: 46),
+            .foregroundColor: UIColor.white
+        ]
+        let nameStr = appName as NSString
+        let nameSize = nameStr.size(withAttributes: nameAttrs)
+        nameStr.draw(at: CGPoint(x: (w - nameSize.width) / 2, y: 48), withAttributes: nameAttrs)
+
+        let subAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 26),
+            .foregroundColor: UIColor.white.withAlphaComponent(0.88)
+        ]
+        let subStr = "データ引き継ぎQRコード" as NSString
+        let subSize = subStr.size(withAttributes: subAttrs)
+        subStr.draw(at: CGPoint(x: (w - subSize.width) / 2, y: 116), withAttributes: subAttrs)
+
+        // ── QRカード ─────────────────────────────────
+        let pad: CGFloat = 64
+        let qrSide = w - pad * 2   // 672
+        let qrY: CGFloat = headerH + 36
+
+        // 外枠（薄グレー）→ 内側白
+        let cardOuter = CGRect(x: pad - 16, y: qrY - 16, width: qrSide + 32, height: qrSide + 32)
+        UIColor(white: 0.92, alpha: 1).setFill()
+        UIBezierPath(roundedRect: cardOuter, cornerRadius: 24).fill()
+        UIColor.white.setFill()
+        UIBezierPath(roundedRect: cardOuter.insetBy(dx: 3, dy: 3), cornerRadius: 22).fill()
+
+        // QRコード描画
+        cg.interpolationQuality = .none
+        qrSource.draw(in: CGRect(x: pad, y: qrY, width: qrSide, height: qrSide))
+
+        // ── フッター ─────────────────────────────────
+        let footerY = qrY + qrSide + 44
+
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "ja_JP")
+        df.dateFormat = "yyyy年M月d日 HH:mm まで有効"
+
+        let expiresAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.monospacedDigitSystemFont(ofSize: 22, weight: .regular),
+            .foregroundColor: UIColor(white: 0.35, alpha: 1)
+        ]
+        let expiresStr = df.string(from: expiresAt) as NSString
+        let expiresSize = expiresStr.size(withAttributes: expiresAttrs)
+        expiresStr.draw(at: CGPoint(x: (w - expiresSize.width) / 2, y: footerY), withAttributes: expiresAttrs)
+
+        let instrAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 20),
+            .foregroundColor: UIColor(white: 0.6, alpha: 1)
+        ]
+        let instrStr = "新しいデバイスのカメラで読み取ってください" as NSString
+        let instrSize = instrStr.size(withAttributes: instrAttrs)
+        instrStr.draw(at: CGPoint(x: (w - instrSize.width) / 2, y: footerY + 36), withAttributes: instrAttrs)
     }
 }
 

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+import CoreImage.CIFilterBuiltins
+
+struct TransferView: View {
+    @State private var viewModel: TransferViewModel
+    @State private var selectedTab = 0
+    @State private var showScanner = false
+    @Environment(\.dismiss) private var dismiss
+
+    init(viewModel: TransferViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $selectedTab) {
+                Text("このデバイスから引き継ぐ").tag(0)
+                Text("別のデバイスに引き継ぐ").tag(1)
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            if selectedTab == 0 {
+                IssueTokenView(viewModel: viewModel)
+            } else {
+                ScanTokenView(viewModel: viewModel)
+            }
+        }
+        .navigationTitle("データ引き継ぎ")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.loadToken() }
+        .alert("引き継ぎ完了", isPresented: $viewModel.transferCompleted) {
+            Button("OK") { dismiss() }
+        } message: {
+            Text("学習データを引き継ぎました。アプリを再起動するとデータが反映されます。")
+        }
+    }
+}
+
+// MARK: - このデバイスから引き継ぐ（QRコード表示）
+
+private struct IssueTokenView: View {
+    var viewModel: TransferViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                VStack(spacing: 8) {
+                    Text("新しいデバイスでこのQRコードを読み取ってください")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                    Text("有効期限: 3年間")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.top)
+
+                if viewModel.isLoading {
+                    ProgressView()
+                        .frame(width: 200, height: 200)
+                } else if let token = viewModel.transferToken {
+                    QRCodeView(content: token.token)
+                        .frame(width: 200, height: 200)
+                    Text(token.token)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+
+                Button {
+                    Task { await viewModel.refreshToken() }
+                } label: {
+                    Label("コードを更新する", systemImage: "arrow.clockwise")
+                        .font(.subheadline)
+                }
+                .disabled(viewModel.isLoading)
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - 別のデバイスに引き継ぐ（QRスキャン）
+
+private struct ScanTokenView: View {
+    var viewModel: TransferViewModel
+    @State private var showScanner = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "qrcode.viewfinder")
+                .font(.system(size: 80))
+                .foregroundStyle(Color.accentColor)
+
+            VStack(spacing: 8) {
+                Text("旧デバイスのQRコードを読み取る")
+                    .font(.headline)
+                Text("引き継ぎ元のデバイスに表示されているQRコードをスキャンしてください")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal)
+            }
+
+            Button {
+                showScanner = true
+            } label: {
+                Group {
+                    if viewModel.isLoading {
+                        ProgressView().tint(.white)
+                    } else {
+                        Label("QRコードをスキャン", systemImage: "camera")
+                            .font(.headline)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.accentColor)
+                .foregroundStyle(.white)
+                .cornerRadius(12)
+            }
+            .disabled(viewModel.isLoading)
+            .padding(.horizontal, 32)
+
+            Spacer()
+        }
+        .sheet(isPresented: $showScanner) {
+            QRScannerView { token in
+                showScanner = false
+                Task { await viewModel.applyToken(token) }
+            }
+        }
+    }
+}
+
+// MARK: - QRコード生成
+
+private struct QRCodeView: View {
+    let content: String
+
+    var body: some View {
+        if let image = generateQRCode(from: content) {
+            Image(uiImage: image)
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+        }
+    }
+
+    private func generateQRCode(from string: String) -> UIImage? {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+
+        guard let outputImage = filter.outputImage,
+              let cgImage = context.createCGImage(outputImage, from: outputImage.extent) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+// MARK: - QRコードスキャナー
+
+private struct QRScannerView: UIViewControllerRepresentable {
+    let onScan: (String) -> Void
+
+    func makeUIViewController(context: Context) -> ScannerViewController {
+        ScannerViewController(onScan: onScan)
+    }
+
+    func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
+}
+
+import AVFoundation
+
+private final class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    let onScan: (String) -> Void
+    private var captureSession: AVCaptureSession?
+
+    init(onScan: @escaping (String) -> Void) {
+        self.onScan = onScan
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        setupCapture()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        captureSession?.stopRunning()
+    }
+
+    private func setupCapture() {
+        let session = AVCaptureSession()
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device),
+              session.canAddInput(input) else { return }
+
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else { return }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: .main)
+        output.metadataObjectTypes = [.qr]
+
+        let preview = AVCaptureVideoPreviewLayer(session: session)
+        preview.frame = view.bounds
+        preview.videoGravity = .resizeAspectFill
+        view.layer.addSublayer(preview)
+
+        captureSession = session
+        DispatchQueue.global(qos: .userInitiated).async { session.startRunning() }
+    }
+
+    func metadataOutput(_ output: AVCaptureMetadataOutput,
+                        didOutput metadataObjects: [AVMetadataObject],
+                        from connection: AVCaptureConnection) {
+        guard let obj = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              let value = obj.stringValue else { return }
+        captureSession?.stopRunning()
+        onScan(value)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TransferView(
+            viewModel: TransferViewModel(
+                fetchTokenUseCase: PreviewAppContainer.makeLearningUseCases().fetchTransferToken,
+                refreshTokenUseCase: PreviewAppContainer.makeLearningUseCases().refreshTransferToken,
+                applyTokenUseCase: PreviewAppContainer.makeLearningUseCases().applyTransferToken,
+                deviceIdentityProvider: PreviewDeviceIdentityProvider()
+            )
+        )
+    }
+}

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -323,7 +323,7 @@ private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date, identityI
                 .font: UIFont.monospacedSystemFont(ofSize: 18, weight: .regular),
                 .foregroundColor: UIColor(white: 0.5, alpha: 1)
             ]
-            let idStr = "ID: \(masked)" as NSString
+            let idStr = "ユーザーID: \(masked)" as NSString
             let idSize = idStr.size(withAttributes: idAttrs)
             idStr.draw(at: CGPoint(x: (w - idSize.width) / 2, y: footerY + 34), withAttributes: idAttrs)
         }

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import CoreImage.CIFilterBuiltins
 import PhotosUI
+import Photos
 import Vision
-import UniformTypeIdentifiers
 import AVFoundation
 
 struct TransferView: View {
@@ -44,6 +44,7 @@ struct TransferView: View {
 
 private struct IssueTokenView: View {
     var viewModel: TransferViewModel
+    @State private var saveMessage: String?
 
     var body: some View {
         ScrollView {
@@ -79,12 +80,17 @@ private struct IssueTokenView: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
 
-                    ShareLink(
-                        item: QRCodePNG(image: scaledQRCode(qrImage)),
-                        preview: SharePreview("引き継ぎQRコード", image: Image(uiImage: qrImage))
-                    ) {
-                        Label("画像として書き出す", systemImage: "square.and.arrow.up")
+                    Button {
+                        Task { await saveQRToPhotos(scaledQRCode(qrImage)) }
+                    } label: {
+                        Label("写真に保存", systemImage: "photo.badge.plus")
                             .font(.subheadline)
+                    }
+
+                    if let msg = saveMessage {
+                        Text(msg)
+                            .font(.caption)
+                            .foregroundStyle(msg.contains("失敗") ? .red : .green)
                     }
                 }
 
@@ -105,6 +111,22 @@ private struct IssueTokenView: View {
                 Spacer()
             }
             .padding()
+        }
+    }
+
+    private func saveQRToPhotos(_ image: UIImage) async {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard status == .authorized || status == .limited else {
+            saveMessage = "写真への保存が許可されていません"
+            return
+        }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                PHAssetChangeRequest.creationRequestForAsset(from: image)
+            }
+            saveMessage = "写真に保存しました"
+        } catch {
+            saveMessage = "保存に失敗しました"
         }
     }
 }
@@ -232,18 +254,6 @@ private func scaledQRCode(_ source: UIImage, size: CGFloat = 1024) -> UIImage {
     return renderer.image { ctx in
         ctx.cgContext.interpolationQuality = .none
         source.draw(in: CGRect(origin: .zero, size: CGSize(width: size, height: size)))
-    }
-}
-
-// MARK: - PNG書き出し用Transferable
-
-private struct QRCodePNG: Transferable {
-    let image: UIImage
-
-    static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation(exportedContentType: .png) { item in
-            item.image.pngData() ?? Data()
-        }
     }
 }
 

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -226,7 +226,7 @@ private struct ScanTokenView: View {
         let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
         try? handler.perform([request])
 
-        guard let token = (request.results as? [VNBarcodeObservation])?
+        guard let token = request.results?
             .first(where: { $0.symbology == .qr })?
             .payloadStringValue else {
             viewModel.errorMessage = "QRコードが見つかりませんでした"
@@ -390,6 +390,15 @@ private final class ScannerViewController: UIViewController, AVCaptureMetadataOu
         captureSession?.stopRunning()
         onScan(value)
     }
+}
+
+#Preview("保存カード") {
+    let qr = generateQRCode(from: "preview-token-abcdef1234567890") ?? UIImage()
+    let card = makeTransferCardImage(qrSource: qr, expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600))
+    Image(uiImage: card)
+        .resizable()
+        .scaledToFit()
+        .padding()
 }
 
 #Preview {

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 import CoreImage.CIFilterBuiltins
+import PhotosUI
+import Vision
+import UniformTypeIdentifiers
+import AVFoundation
 
 struct TransferView: View {
     @State private var viewModel: TransferViewModel
     @State private var selectedTab = 0
-    @State private var showScanner = false
     @Environment(\.dismiss) private var dismiss
 
     init(viewModel: TransferViewModel) {
@@ -37,7 +40,7 @@ struct TransferView: View {
     }
 }
 
-// MARK: - このデバイスから引き継ぐ（QRコード表示）
+// MARK: - このデバイスから引き継ぐ（QRコード表示・書き出し）
 
 private struct IssueTokenView: View {
     var viewModel: TransferViewModel
@@ -50,24 +53,39 @@ private struct IssueTokenView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
-                    Text("有効期限: 3年間")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if let expiresAt = viewModel.transferToken?.expiresAt {
+                        Text("有効期限: \(expiresAt.formatted(.dateTime.year().month().day().locale(Locale(identifier: "ja_JP"))))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 .padding(.top)
 
                 if viewModel.isLoading {
                     ProgressView()
                         .frame(width: 200, height: 200)
-                } else if let token = viewModel.transferToken {
-                    QRCodeView(content: token.token)
+                } else if let token = viewModel.transferToken,
+                          let qrImage = generateQRCode(from: token.token) {
+                    Image(uiImage: qrImage)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
                         .frame(width: 200, height: 200)
+
                     Text(token.token)
                         .font(.system(.caption2, design: .monospaced))
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
+
+                    ShareLink(
+                        item: QRCodePNG(image: scaledQRCode(qrImage)),
+                        preview: SharePreview("引き継ぎQRコード", image: Image(uiImage: qrImage))
+                    ) {
+                        Label("画像として書き出す", systemImage: "square.and.arrow.up")
+                            .font(.subheadline)
+                    }
                 }
 
                 if let error = viewModel.errorMessage {
@@ -91,11 +109,12 @@ private struct IssueTokenView: View {
     }
 }
 
-// MARK: - 別のデバイスに引き継ぐ（QRスキャン）
+// MARK: - 別のデバイスに引き継ぐ（QRスキャン・画像読み込み）
 
 private struct ScanTokenView: View {
     var viewModel: TransferViewModel
     @State private var showScanner = false
+    @State private var selectedPhoto: PhotosPickerItem?
 
     var body: some View {
         VStack(spacing: 24) {
@@ -108,7 +127,7 @@ private struct ScanTokenView: View {
             VStack(spacing: 8) {
                 Text("旧デバイスのQRコードを読み取る")
                     .font(.headline)
-                Text("引き継ぎ元のデバイスに表示されているQRコードをスキャンしてください")
+                Text("引き継ぎ元のデバイスに表示されているQRコードをスキャン、または保存した画像から読み込んでください")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -122,24 +141,37 @@ private struct ScanTokenView: View {
                     .padding(.horizontal)
             }
 
-            Button {
-                showScanner = true
-            } label: {
-                Group {
-                    if viewModel.isLoading {
-                        ProgressView().tint(.white)
-                    } else {
-                        Label("QRコードをスキャン", systemImage: "camera")
-                            .font(.headline)
+            VStack(spacing: 12) {
+                Button {
+                    showScanner = true
+                } label: {
+                    Group {
+                        if viewModel.isLoading {
+                            ProgressView().tint(.white)
+                        } else {
+                            Label("QRコードをスキャン", systemImage: "camera")
+                                .font(.headline)
+                        }
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundStyle(.white)
+                    .cornerRadius(12)
                 }
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.accentColor)
-                .foregroundStyle(.white)
-                .cornerRadius(12)
+                .disabled(viewModel.isLoading)
+
+                PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                    Label("画像から読み込む", systemImage: "photo")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color(.systemGray5))
+                        .foregroundStyle(Color.accentColor)
+                        .cornerRadius(12)
+                }
+                .disabled(viewModel.isLoading)
             }
-            .disabled(viewModel.isLoading)
             .padding(.horizontal, 32)
 
             Spacer()
@@ -150,38 +182,72 @@ private struct ScanTokenView: View {
                 Task { await viewModel.applyToken(token) }
             }
         }
-    }
-}
-
-// MARK: - QRコード生成
-
-private struct QRCodeView: View {
-    let content: String
-
-    var body: some View {
-        if let image = generateQRCode(from: content) {
-            Image(uiImage: image)
-                .interpolation(.none)
-                .resizable()
-                .scaledToFit()
+        .onChange(of: selectedPhoto) { _, item in
+            guard let item else { return }
+            Task {
+                await decodeQRFromPhoto(item)
+                selectedPhoto = nil
+            }
         }
     }
 
-    private func generateQRCode(from string: String) -> UIImage? {
-        let context = CIContext()
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(string.utf8)
-        filter.correctionLevel = "M"
-
-        guard let outputImage = filter.outputImage,
-              let cgImage = context.createCGImage(outputImage, from: outputImage.extent) else {
-            return nil
+    private func decodeQRFromPhoto(_ item: PhotosPickerItem) async {
+        guard let data = try? await item.loadTransferable(type: Data.self),
+              let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else {
+            viewModel.errorMessage = "画像の読み込みに失敗しました"
+            return
         }
-        return UIImage(cgImage: cgImage)
+
+        let request = VNDetectBarcodesRequest()
+        request.symbologies = [.qr]
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try? handler.perform([request])
+
+        guard let token = (request.results as? [VNBarcodeObservation])?
+            .first(where: { $0.symbology == .qr })?
+            .payloadStringValue else {
+            viewModel.errorMessage = "QRコードが見つかりませんでした"
+            return
+        }
+
+        await viewModel.applyToken(token)
     }
 }
 
-// MARK: - QRコードスキャナー
+// MARK: - QRコード生成ヘルパー
+
+private func generateQRCode(from string: String) -> UIImage? {
+    let context = CIContext()
+    let filter = CIFilter.qrCodeGenerator()
+    filter.message = Data(string.utf8)
+    filter.correctionLevel = "M"
+    guard let outputImage = filter.outputImage,
+          let cgImage = context.createCGImage(outputImage, from: outputImage.extent) else { return nil }
+    return UIImage(cgImage: cgImage)
+}
+
+private func scaledQRCode(_ source: UIImage, size: CGFloat = 1024) -> UIImage {
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+    return renderer.image { ctx in
+        ctx.cgContext.interpolationQuality = .none
+        source.draw(in: CGRect(origin: .zero, size: CGSize(width: size, height: size)))
+    }
+}
+
+// MARK: - PNG書き出し用Transferable
+
+private struct QRCodePNG: Transferable {
+    let image: UIImage
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .png) { item in
+            item.image.pngData() ?? Data()
+        }
+    }
+}
+
+// MARK: - QRコードスキャナー（カメラ）
 
 private struct QRScannerView: UIViewControllerRepresentable {
     let onScan: (String) -> Void
@@ -192,8 +258,6 @@ private struct QRScannerView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
 }
-
-import AVFoundation
 
 private final class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
     let onScan: (String) -> Void

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -81,7 +81,7 @@ private struct IssueTokenView: View {
                         .padding(.horizontal)
 
                     Button {
-                        Task { await saveQRToPhotos(makeTransferCardImage(qrSource: qrImage, expiresAt: token.expiresAt)) }
+                        Task { await saveQRToPhotos(makeTransferCardImage(qrSource: qrImage, expiresAt: token.expiresAt, identityId: viewModel.deviceIdentityId)) }
                     } label: {
                         Label("写真に保存", systemImage: "photo.badge.plus")
                             .font(.subheadline)
@@ -249,9 +249,9 @@ private func generateQRCode(from string: String) -> UIImage? {
     return UIImage(cgImage: cgImage)
 }
 
-private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date) -> UIImage {
+private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date, identityId: String?) -> UIImage {
     let w: CGFloat = 800
-    let h: CGFloat = 1000
+    let h: CGFloat = 1060
     let accentColor = UIColor(named: "main") ?? .systemGreen
 
     let renderer = UIGraphicsImageRenderer(size: CGSize(width: w, height: h))
@@ -315,13 +315,26 @@ private func makeTransferCardImage(qrSource: UIImage, expiresAt: Date) -> UIImag
         let expiresSize = expiresStr.size(withAttributes: expiresAttrs)
         expiresStr.draw(at: CGPoint(x: (w - expiresSize.width) / 2, y: footerY), withAttributes: expiresAttrs)
 
+        if let id = identityId {
+            let masked = id.count > 14
+                ? "\(id.prefix(6))...\(id.suffix(6))"
+                : id
+            let idAttrs: [NSAttributedString.Key: Any] = [
+                .font: UIFont.monospacedSystemFont(ofSize: 18, weight: .regular),
+                .foregroundColor: UIColor(white: 0.5, alpha: 1)
+            ]
+            let idStr = "ID: \(masked)" as NSString
+            let idSize = idStr.size(withAttributes: idAttrs)
+            idStr.draw(at: CGPoint(x: (w - idSize.width) / 2, y: footerY + 34), withAttributes: idAttrs)
+        }
+
         let instrAttrs: [NSAttributedString.Key: Any] = [
             .font: UIFont.systemFont(ofSize: 20),
             .foregroundColor: UIColor(white: 0.6, alpha: 1)
         ]
         let instrStr = "新しいデバイスのカメラで読み取ってください" as NSString
         let instrSize = instrStr.size(withAttributes: instrAttrs)
-        instrStr.draw(at: CGPoint(x: (w - instrSize.width) / 2, y: footerY + 36), withAttributes: instrAttrs)
+        instrStr.draw(at: CGPoint(x: (w - instrSize.width) / 2, y: footerY + 68), withAttributes: instrAttrs)
     }
 }
 
@@ -394,7 +407,7 @@ private final class ScannerViewController: UIViewController, AVCaptureMetadataOu
 
 #Preview("保存カード", traits: .fixedLayout(width: 400, height: 500)) {
     let qr = generateQRCode(from: "preview-token-abcdef1234567890") ?? UIImage()
-    let card = makeTransferCardImage(qrSource: qr, expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600))
+    let card = makeTransferCardImage(qrSource: qr, expiresAt: Date().addingTimeInterval(3 * 365 * 24 * 3600), identityId: "ap-northeast-1:51acc74e-ec8d-4de4-bfa1-84648ea45222")
     Image(uiImage: card)
         .resizable()
         .scaledToFit()

--- a/ios/Rikako/Screen/Transfer/TransferView.swift
+++ b/ios/Rikako/Screen/Transfer/TransferView.swift
@@ -54,7 +54,7 @@ private struct IssueTokenView: View {
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                     if let expiresAt = viewModel.transferToken?.expiresAt {
-                        Text("有効期限: \(expiresAt.formatted(.dateTime.year().month().day().locale(Locale(identifier: "ja_JP"))))")
+                        Text("有効期限: \(expiresAt.formatted(.dateTime.year().month().day().hour().minute().locale(Locale(identifier: "ja_JP"))))")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/ios/Rikako/Screen/Transfer/TransferViewModel.swift
+++ b/ios/Rikako/Screen/Transfer/TransferViewModel.swift
@@ -56,6 +56,8 @@ final class TransferViewModel {
             let identityId = try await applyTokenUseCase.execute(token: token)
             deviceIdentityProvider.overrideIdentityId(identityId)
             transferCompleted = true
+        } catch APIError.sameDevice {
+            errorMessage = "このQRコードは同じデバイスで発行されています。別のデバイスのQRコードを読み取ってください"
         } catch {
             errorMessage = "引き継ぎに失敗しました。コードが正しいか確認してください"
         }

--- a/ios/Rikako/Screen/Transfer/TransferViewModel.swift
+++ b/ios/Rikako/Screen/Transfer/TransferViewModel.swift
@@ -5,7 +5,6 @@ import Observation
 @MainActor
 final class TransferViewModel {
     var transferToken: TransferToken?
-    var deviceIdentityId: String?
     var isLoading = false
     var errorMessage: String?
     var transferCompleted = false
@@ -33,7 +32,6 @@ final class TransferViewModel {
         defer { isLoading = false }
         do {
             transferToken = try await fetchTokenUseCase.execute()
-            deviceIdentityId = try? await deviceIdentityProvider.getIdentityId()
         } catch {
             errorMessage = "引き継ぎコードの取得に失敗しました"
         }

--- a/ios/Rikako/Screen/Transfer/TransferViewModel.swift
+++ b/ios/Rikako/Screen/Transfer/TransferViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class TransferViewModel {
+    var transferToken: TransferToken?
+    var isLoading = false
+    var errorMessage: String?
+    var transferCompleted = false
+
+    private let fetchTokenUseCase: FetchTransferTokenUseCase
+    private let refreshTokenUseCase: RefreshTransferTokenUseCase
+    private let applyTokenUseCase: ApplyTransferTokenUseCase
+    private let deviceIdentityProvider: DeviceIdentityProviding
+
+    init(
+        fetchTokenUseCase: FetchTransferTokenUseCase,
+        refreshTokenUseCase: RefreshTransferTokenUseCase,
+        applyTokenUseCase: ApplyTransferTokenUseCase,
+        deviceIdentityProvider: DeviceIdentityProviding
+    ) {
+        self.fetchTokenUseCase = fetchTokenUseCase
+        self.refreshTokenUseCase = refreshTokenUseCase
+        self.applyTokenUseCase = applyTokenUseCase
+        self.deviceIdentityProvider = deviceIdentityProvider
+    }
+
+    func loadToken() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            transferToken = try await fetchTokenUseCase.execute()
+        } catch {
+            errorMessage = "引き継ぎコードの取得に失敗しました"
+        }
+    }
+
+    func refreshToken() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            transferToken = try await refreshTokenUseCase.execute()
+        } catch {
+            errorMessage = "引き継ぎコードの更新に失敗しました"
+        }
+    }
+
+    func applyToken(_ token: String) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            let identityId = try await applyTokenUseCase.execute(token: token)
+            deviceIdentityProvider.overrideIdentityId(identityId)
+            transferCompleted = true
+        } catch {
+            errorMessage = "引き継ぎに失敗しました。コードが正しいか確認してください"
+        }
+    }
+}

--- a/ios/Rikako/Screen/Transfer/TransferViewModel.swift
+++ b/ios/Rikako/Screen/Transfer/TransferViewModel.swift
@@ -5,6 +5,7 @@ import Observation
 @MainActor
 final class TransferViewModel {
     var transferToken: TransferToken?
+    var deviceIdentityId: String?
     var isLoading = false
     var errorMessage: String?
     var transferCompleted = false
@@ -32,6 +33,7 @@ final class TransferViewModel {
         defer { isLoading = false }
         do {
             transferToken = try await fetchTokenUseCase.execute()
+            deviceIdentityId = try? await deviceIdentityProvider.getIdentityId()
         } catch {
             errorMessage = "引き継ぎコードの取得に失敗しました"
         }


### PR DESCRIPTION
## 概要

- プロフィール画面に「データ引き継ぎ」メニューを追加
- QRコード表示（旧端末）とQRスキャン（新端末）の両方に対応
- バックエンドPR #173で実装した引き継ぎトークンAPIと連携

## 変更内容

- `DeviceIdentityProvider`: `overrideIdentityId()` をプロトコルと実装に追加（機種変更時にKeychainのidentity_idを上書き）
- `LearningRepository`: `TransferToken` 型と `fetchTransferToken` / `refreshTransferToken` / `applyTransferToken` を追加
- `RemoteLearningRepository`: 引き継ぎトークン3エンドポイントのHTTP実装
- `LearningUseCases`: 3つのユースケース構造体を追加
- `AppContainer`: `deviceIdentityProvider` をpublicプロパティとして公開
- `TransferViewModel`: トークン取得・更新・適用ロジック（`@Observable`）
- `TransferView`: セグメントピッカーで旧端末用QR表示と新端末用スキャンを切り替え
  - QR生成: CoreImage `CIFilter.qrCodeGenerator()`
  - QRスキャン: AVFoundation `AVCaptureMetadataOutput`
- `ProfileView`: 「データ管理」セクションに「データ引き継ぎ」NavigationLinkを追加
- `PreviewLearningRepository`: プレビュー用スタブと `PreviewDeviceIdentityProvider` を追加

## テスト計画

- [ ] プロフィール画面に「データ管理」セクションが表示される
- [ ] 「データ引き継ぎ」をタップするとTransferViewに遷移する
- [ ] 「このデバイスから引き継ぐ」タブでQRコードが表示される
- [ ] 「コードを更新する」でQRコードが更新される
- [ ] 「別のデバイスに引き継ぐ」タブでスキャンボタンが表示される
- [ ] QRスキャン後に引き継ぎ完了アラートが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)