### PR TITLE
StudyHomeView のローディングを初回のみ表示（stale-while-revalidate）

### DIFF
--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -4,7 +4,6 @@ struct StudyHomeView: View {
     @Environment(AppState.self) private var appState
     @State private var viewModel: StudyHomeViewModel
     @State private var workbookProgress: [String: Bool] = [:]
-    @State private var isProgressLoading = true
     @State private var showingQuiz = false
     @State private var pendingQuizConfig: QuizLaunchConfig? = nil
     private let isPreview: Bool
@@ -37,7 +36,7 @@ struct StudyHomeView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if viewModel.isLoading || isProgressLoading {
+                if viewModel.workbooks.isEmpty {
                     skeletonView
                 } else if let errorMessage = viewModel.errorMessage {
                     ContentUnavailableView {
@@ -104,13 +103,11 @@ struct StudyHomeView: View {
         }
         .task(id: appState.lastQuizCompletionID) {
             guard !isPreview, appState.lastQuizCompletionID > 0 else { return }
-            await loadWorkbookProgress(showLoading: false)
+            await loadWorkbookProgress()
         }
     }
 
-    private func loadWorkbookProgress(showLoading: Bool = true) async {
-        if showLoading && workbookProgress.isEmpty { isProgressLoading = true }
-        defer { isProgressLoading = false }
+    private func loadWorkbookProgress() async {
         guard let workbookId = appState.selectedWorkbookID else { return }
         let response = try? await AppContainer.shared.learningUseCases.fetchWorkbookProgress.execute(workbookId: workbookId)
         workbookProgress = Dictionary(uniqueKeysWithValues: (response?.results ?? []).map { (String($0.questionId), $0.isCorrect) })


### PR DESCRIPTION
## 変更内容

StudyHomeView を開くたびにスケルトンが表示されてしまう問題を修正。

**変更前の挙動：**
- `isProgressLoading` フラグがスケルトン表示を制御していたため、`.task` が再実行されるタイミング（tab 切り替えなど）でフラッシュが発生することがあった

**変更後の挙動：**
- スケルトンは `workbooks.isEmpty`（データが未取得）のときのみ表示
- 2回目以降はデータをそのまま表示しつつ、ネットワーク更新を裏で実行
- `isProgressLoading` ステートと `showLoading` 引数を削除してシンプル化

## 影響範囲

- `StudyHomeView.swift` のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)