### PR TITLE
Fix workbook update timeout with bulk insert

### DIFF
--- a/app/internal/admin/handler.go
+++ b/app/internal/admin/handler.go
@@ -807,19 +807,21 @@ func (h *Handler) CreateWorkbook(ctx context.Context, request adminapi.CreateWor
 
 func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWorkbookRequestObject) (adminapi.UpdateWorkbookResponseObject, error) {
 	body := request.Body
+	h.logger.Info("UpdateWorkbook: start", "workbook_id", request.WorkbookId)
 
 	tx, err := h.sqlDB.BeginTx(ctx, nil)
 	if err != nil {
-		h.logger.Error("failed to begin transaction", "error", err)
+		h.logger.Error("UpdateWorkbook: failed to begin transaction", "error", err)
 		return nil, err
 	}
 	defer tx.Rollback()
 
 	qtx := h.queries.WithTx(tx)
 
+	h.logger.Info("UpdateWorkbook: checking existence", "workbook_id", request.WorkbookId)
 	exists, err := qtx.WorkbookExists(ctx, request.WorkbookId)
 	if err != nil {
-		h.logger.Error("failed to check workbook existence", "error", err)
+		h.logger.Error("UpdateWorkbook: failed to check workbook existence", "error", err)
 		return nil, err
 	}
 	if !exists {
@@ -838,6 +840,7 @@ func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWor
 	if body.IsPublished != nil {
 		isPublished = *body.IsPublished
 	}
+	h.logger.Info("UpdateWorkbook: updating row", "workbook_id", request.WorkbookId, "is_published", isPublished)
 	err = qtx.UpdateWorkbook(ctx, db.UpdateWorkbookParams{
 		Title:       body.Title,
 		Description: desc,
@@ -847,16 +850,19 @@ func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWor
 		ID:          request.WorkbookId,
 	})
 	if err != nil {
-		h.logger.Error("failed to update workbook", "error", err)
+		h.logger.Error("UpdateWorkbook: failed to update workbook", "error", err)
 		return nil, err
 	}
 
+	h.logger.Info("UpdateWorkbook: deleting questions", "workbook_id", request.WorkbookId)
 	err = qtx.DeleteWorkbookQuestions(ctx, request.WorkbookId)
 	if err != nil {
-		h.logger.Error("failed to delete old workbook questions", "error", err)
+		h.logger.Error("UpdateWorkbook: failed to delete old workbook questions", "error", err)
 		return nil, err
 	}
+	questionCount := 0
 	if body.QuestionIds != nil {
+		questionCount = len(*body.QuestionIds)
 		for i, qID := range *body.QuestionIds {
 			err = qtx.CreateWorkbookQuestion(ctx, db.CreateWorkbookQuestionParams{
 				WorkbookID: request.WorkbookId,
@@ -864,23 +870,27 @@ func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWor
 				OrderIndex: int32(i),
 			})
 			if err != nil {
-				h.logger.Error("failed to insert workbook question", "error", err, "question_id", qID)
+				h.logger.Error("UpdateWorkbook: failed to insert workbook question", "error", err, "question_id", qID)
 				return nil, err
 			}
 		}
 	}
+	h.logger.Info("UpdateWorkbook: questions inserted", "count", questionCount)
 
+	h.logger.Info("UpdateWorkbook: committing")
 	if err := tx.Commit(); err != nil {
-		h.logger.Error("failed to commit transaction", "error", err)
+		h.logger.Error("UpdateWorkbook: failed to commit transaction", "error", err)
 		return nil, err
 	}
 
+	h.logger.Info("UpdateWorkbook: fetching detail", "workbook_id", request.WorkbookId)
 	w, err := h.getWorkbookDetail(ctx, request.WorkbookId)
 	if err != nil {
-		h.logger.Error("failed to get updated workbook", "error", err)
+		h.logger.Error("UpdateWorkbook: failed to get updated workbook", "error", err)
 		return nil, err
 	}
 
+	h.logger.Info("UpdateWorkbook: done", "workbook_id", request.WorkbookId)
 	return adminapi.UpdateWorkbook200JSONResponse(*w), nil
 }
 

--- a/app/internal/admin/handler.go
+++ b/app/internal/admin/handler.go
@@ -816,21 +816,19 @@ func (h *Handler) CreateWorkbook(ctx context.Context, request adminapi.CreateWor
 
 func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWorkbookRequestObject) (adminapi.UpdateWorkbookResponseObject, error) {
 	body := request.Body
-	h.logger.Info("UpdateWorkbook: start", "workbook_id", request.WorkbookId)
 
 	tx, err := h.sqlDB.BeginTx(ctx, nil)
 	if err != nil {
-		h.logger.Error("UpdateWorkbook: failed to begin transaction", "error", err)
+		h.logger.Error("failed to begin transaction", "error", err)
 		return nil, err
 	}
 	defer tx.Rollback()
 
 	qtx := h.queries.WithTx(tx)
 
-	h.logger.Info("UpdateWorkbook: checking existence", "workbook_id", request.WorkbookId)
 	exists, err := qtx.WorkbookExists(ctx, request.WorkbookId)
 	if err != nil {
-		h.logger.Error("UpdateWorkbook: failed to check workbook existence", "error", err)
+		h.logger.Error("failed to check workbook existence", "error", err)
 		return nil, err
 	}
 	if !exists {
@@ -849,7 +847,6 @@ func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWor
 	if body.IsPublished != nil {
 		isPublished = *body.IsPublished
 	}
-	h.logger.Info("UpdateWorkbook: updating row", "workbook_id", request.WorkbookId, "is_published", isPublished)
 	err = qtx.UpdateWorkbook(ctx, db.UpdateWorkbookParams{
 		Title:       body.Title,
 		Description: desc,
@@ -859,40 +856,33 @@ func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWor
 		ID:          request.WorkbookId,
 	})
 	if err != nil {
-		h.logger.Error("UpdateWorkbook: failed to update workbook", "error", err)
+		h.logger.Error("failed to update workbook", "error", err)
 		return nil, err
 	}
 
-	h.logger.Info("UpdateWorkbook: deleting questions", "workbook_id", request.WorkbookId)
 	err = qtx.DeleteWorkbookQuestions(ctx, request.WorkbookId)
 	if err != nil {
-		h.logger.Error("UpdateWorkbook: failed to delete old workbook questions", "error", err)
+		h.logger.Error("failed to delete old workbook questions", "error", err)
 		return nil, err
 	}
-	questionCount := 0
 	if body.QuestionIds != nil {
-		questionCount = len(*body.QuestionIds)
 		if err := bulkInsertWorkbookQuestions(ctx, tx, request.WorkbookId, *body.QuestionIds); err != nil {
-			h.logger.Error("UpdateWorkbook: failed to insert workbook questions", "error", err)
+			h.logger.Error("failed to insert workbook questions", "error", err)
 			return nil, err
 		}
 	}
-	h.logger.Info("UpdateWorkbook: questions inserted", "count", questionCount)
 
-	h.logger.Info("UpdateWorkbook: committing")
 	if err := tx.Commit(); err != nil {
-		h.logger.Error("UpdateWorkbook: failed to commit transaction", "error", err)
+		h.logger.Error("failed to commit transaction", "error", err)
 		return nil, err
 	}
 
-	h.logger.Info("UpdateWorkbook: fetching detail", "workbook_id", request.WorkbookId)
 	w, err := h.getWorkbookDetail(ctx, request.WorkbookId)
 	if err != nil {
-		h.logger.Error("UpdateWorkbook: failed to get updated workbook", "error", err)
+		h.logger.Error("failed to get updated workbook", "error", err)
 		return nil, err
 	}
 
-	h.logger.Info("UpdateWorkbook: done", "workbook_id", request.WorkbookId)
 	return adminapi.UpdateWorkbook200JSONResponse(*w), nil
 }
 

--- a/app/internal/admin/handler.go
+++ b/app/internal/admin/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/takoikatakotako/rikako/internal/adminapi"
 	"github.com/takoikatakotako/rikako/internal/db"
 )
@@ -602,6 +603,21 @@ func (h *Handler) DeleteQuestion(ctx context.Context, request adminapi.DeleteQue
 
 // --- Workbooks CRUD ---
 
+// bulkInsertWorkbookQuestions inserts all question IDs for a workbook in a single query.
+func bulkInsertWorkbookQuestions(ctx context.Context, tx *sql.Tx, workbookID int64, questionIDs []int64) error {
+	if len(questionIDs) == 0 {
+		return nil
+	}
+	_, err := tx.ExecContext(ctx,
+		`INSERT INTO workbook_questions (workbook_id, question_id, order_index)
+		 SELECT $1, q, (row_number() OVER () - 1)::int
+		 FROM unnest($2::bigint[]) q`,
+		workbookID,
+		pq.Array(questionIDs),
+	)
+	return err
+}
+
 func (h *Handler) GetWorkbooks(ctx context.Context, request adminapi.GetWorkbooksRequestObject) (adminapi.GetWorkbooksResponseObject, error) {
 	limit, offset, err := validatePagination(request.Params.Limit, request.Params.Offset)
 	if err != nil {
@@ -778,16 +794,9 @@ func (h *Handler) CreateWorkbook(ctx context.Context, request adminapi.CreateWor
 	}
 
 	if body.QuestionIds != nil {
-		for i, qID := range *body.QuestionIds {
-			err = qtx.CreateWorkbookQuestion(ctx, db.CreateWorkbookQuestionParams{
-				WorkbookID: workbookID,
-				QuestionID: qID,
-				OrderIndex: int32(i),
-			})
-			if err != nil {
-				h.logger.Error("failed to insert workbook question", "error", err, "question_id", qID)
-				return nil, err
-			}
+		if err := bulkInsertWorkbookQuestions(ctx, tx, workbookID, *body.QuestionIds); err != nil {
+			h.logger.Error("failed to insert workbook questions", "error", err)
+			return nil, err
 		}
 	}
 
@@ -863,16 +872,9 @@ func (h *Handler) UpdateWorkbook(ctx context.Context, request adminapi.UpdateWor
 	questionCount := 0
 	if body.QuestionIds != nil {
 		questionCount = len(*body.QuestionIds)
-		for i, qID := range *body.QuestionIds {
-			err = qtx.CreateWorkbookQuestion(ctx, db.CreateWorkbookQuestionParams{
-				WorkbookID: request.WorkbookId,
-				QuestionID: qID,
-				OrderIndex: int32(i),
-			})
-			if err != nil {
-				h.logger.Error("UpdateWorkbook: failed to insert workbook question", "error", err, "question_id", qID)
-				return nil, err
-			}
+		if err := bulkInsertWorkbookQuestions(ctx, tx, request.WorkbookId, *body.QuestionIds); err != nil {
+			h.logger.Error("UpdateWorkbook: failed to insert workbook questions", "error", err)
+			return nil, err
 		}
 	}
 	h.logger.Info("UpdateWorkbook: questions inserted", "count", questionCount)


### PR DESCRIPTION
## Summary
- 問題集の更新（PUT /workbooks/:id）が30秒タイムアウトで失敗していたバグを修正
- 原因：100問 × 個別INSERT × ~200ms（東京→シンガポール）≈ 20秒でLambdaタイムアウト
- 修正：`unnest` を使った1クエリの bulk INSERT に変更
- `CreateWorkbook` も同様に修正
- `is_published` 追加とは無関係の既存バグ

## Test plan
- [x] `go test ./internal/admin/` パス確認済み
- [x] dev環境で100問の問題集の更新を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)