### PR TITLE
feat: prod環境のTerraform構成とデプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy-admin-api-prod.yml
+++ b/.github/workflows/deploy-admin-api-prod.yml
@@ -1,0 +1,103 @@
+name: Deploy Admin API Prod
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-1
+  ENVIRONMENT: prod
+
+jobs:
+  build-and-push:
+    name: Build and Push Admin API Docker Image
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "579039992557"
+
+      - name: Extract metadata for Docker
+        id: meta
+        run: |
+          ECR_REGISTRY=579039992557.dkr.ecr.ap-northeast-1.amazonaws.com
+          ECR_REPOSITORY=rikako-admin-api
+          IMAGE_TAG=${{ env.ENVIRONMENT }}
+          echo "tags=${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "Image tag: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+
+      - name: Build and push Docker image
+        run: |
+          docker build -f app/Dockerfile.admin -t ${{ steps.meta.outputs.tags }} .
+          docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Update Lambda function
+        env:
+          FUNCTION_NAME: rikako-admin-api-production
+        run: |
+          aws lambda update-function-code \
+            --function-name "$FUNCTION_NAME" \
+            --image-uri "${{ steps.meta.outputs.tags }}" \
+            --publish
+
+          echo "Waiting for function update to complete..."
+          aws lambda wait function-updated \
+            --function-name "$FUNCTION_NAME"
+
+      - name: Smoke tests
+        env:
+          ADMIN_API_URL: https://admin.rikako.jp/api
+        run: |
+          ADMIN_BASIC_AUTH_USER=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-user --query 'Parameter.Value' --output text)
+          ADMIN_BASIC_AUTH_PASSWORD=$(aws ssm get-parameter --with-decryption --name /rikako/admin-basic-auth-password --query 'Parameter.Value' --output text)
+          FAILED=0
+
+          check_endpoint() {
+            local name="$1"
+            local url="$2"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -L \
+              -u "${ADMIN_BASIC_AUTH_USER}:${ADMIN_BASIC_AUTH_PASSWORD}" \
+              "$url")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ $name (HTTP $STATUS)"
+            else
+              echo "❌ $name (HTTP $STATUS)"
+              FAILED=1
+            fi
+          }
+
+          echo "Running smoke tests..."
+          check_endpoint "Admin API /health" "${ADMIN_API_URL}/health"
+          check_endpoint "Admin API /categories" "${ADMIN_API_URL}/categories"
+          check_endpoint "Admin API /workbooks" "${ADMIN_API_URL}/workbooks"
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "::error::Smoke tests failed"
+            exit 1
+          fi
+          echo "All smoke tests passed"
+
+      - name: Print summary
+        run: |
+          echo "## Deploy Complete! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** ${{ env.ENVIRONMENT }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Image Tag:** \`${{ steps.meta.outputs.tags }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Lambda Function:** rikako-admin-api-production" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-admin-frontend-prod.yml
+++ b/.github/workflows/deploy-admin-frontend-prod.yml
@@ -1,0 +1,68 @@
+name: Deploy Admin Frontend Prod
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-1
+  S3_BUCKET: rikako-admin-production
+  CLOUDFRONT_DISTRIBUTION_ID: "E2IGYEYOGP71VG"
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy Admin Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: admin/package-lock.json
+
+      - name: Install dependencies
+        working-directory: admin
+        run: npm ci
+
+      - name: Build
+        working-directory: admin
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to S3
+        working-directory: admin
+        run: |
+          aws s3 sync out/ s3://${{ env.S3_BUCKET }}/ \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "*.html" \
+            --exclude "*.txt"
+          aws s3 sync out/ s3://${{ env.S3_BUCKET }}/ \
+            --cache-control "public, max-age=0, must-revalidate" \
+            --include "*.html" \
+            --include "*.txt"
+
+      - name: Invalidate CloudFront cache
+        if: env.CLOUDFRONT_DISTRIBUTION_ID != ''
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
+
+      - name: Print summary
+        run: |
+          echo "## Admin Frontend Deploy Complete! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**S3 Bucket:** ${{ env.S3_BUCKET }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-api-prod.yml
+++ b/.github/workflows/deploy-api-prod.yml
@@ -1,0 +1,99 @@
+name: Deploy API Prod
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-1
+  ENVIRONMENT: prod
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "579039992557"
+
+      - name: Extract metadata for Docker
+        id: meta
+        run: |
+          ECR_REGISTRY=579039992557.dkr.ecr.ap-northeast-1.amazonaws.com
+          ECR_REPOSITORY=rikako-api
+          IMAGE_TAG=${{ env.ENVIRONMENT }}
+          echo "tags=${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "Image tag: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+
+      - name: Build and push Docker image
+        run: |
+          docker build -f app/Dockerfile.lambda -t ${{ steps.meta.outputs.tags }} .
+          docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Update Lambda function
+        env:
+          FUNCTION_NAME: rikako-api-production
+        run: |
+          aws lambda update-function-code \
+            --function-name "$FUNCTION_NAME" \
+            --image-uri "${{ steps.meta.outputs.tags }}" \
+            --publish
+
+          echo "Waiting for function update to complete..."
+          aws lambda wait function-updated \
+            --function-name "$FUNCTION_NAME"
+
+      - name: Smoke tests
+        env:
+          API_URL: https://api.rikako.jp
+          CONTENT_URL: https://content.rikako.jp
+        run: |
+          FAILED=0
+
+          check_endpoint() {
+            local name="$1"
+            local url="$2"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ $name (HTTP $STATUS)"
+            else
+              echo "❌ $name (HTTP $STATUS)"
+              FAILED=1
+            fi
+          }
+
+          echo "Running smoke tests..."
+          check_endpoint "Public API /health" "${API_URL}/health"
+          check_endpoint "Content CDN workbooks.json" "${CONTENT_URL}/v1/workbooks.json"
+          check_endpoint "Content CDN categories.json" "${CONTENT_URL}/v1/categories.json"
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "::error::Smoke tests failed"
+            exit 1
+          fi
+          echo "All smoke tests passed"
+
+      - name: Print summary
+        run: |
+          echo "## Deploy Complete! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** ${{ env.ENVIRONMENT }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Image Tag:** \`${{ steps.meta.outputs.tags }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Lambda Function:** rikako-api-production" >> $GITHUB_STEP_SUMMARY

--- a/app/internal/handler/handler_test.go
+++ b/app/internal/handler/handler_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRoot(t *testing.T) {
-	h := New(testDB, "https://example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 	resp, err := h.Root(context.Background(), api.RootRequestObject{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -53,7 +53,7 @@ func TestRoot(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	h := New(testDB, "https://example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 	resp, err := h.HealthCheck(context.Background(), api.HealthCheckRequestObject{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -69,7 +69,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestGetQuestions(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 
 	t.Run("default pagination", func(t *testing.T) {
 		resp, err := h.GetQuestions(context.Background(), api.GetQuestionsRequestObject{})
@@ -173,7 +173,7 @@ func TestGetQuestions(t *testing.T) {
 }
 
 func TestGetQuestion(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 
 	t.Run("existing question", func(t *testing.T) {
 		var dbID int64
@@ -223,7 +223,7 @@ func TestGetQuestion(t *testing.T) {
 }
 
 func TestGetWorkbooks(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 
 	t.Run("default", func(t *testing.T) {
 		resp, err := h.GetWorkbooks(context.Background(), api.GetWorkbooksRequestObject{})
@@ -268,7 +268,7 @@ func TestGetWorkbooks(t *testing.T) {
 }
 
 func TestGetWorkbook(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 
 	t.Run("existing workbook", func(t *testing.T) {
 		var dbID int64
@@ -315,7 +315,7 @@ func TestGetWorkbook(t *testing.T) {
 }
 
 func TestGetQuestionsWithImages(t *testing.T) {
-	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""))
+	h := New(testDB, "https://cdn.example.com", "1.0.0", "1.0.0", testLogger, &identity.MockProvider{}, openai.NewClient(""), "")
 
 	// Fetch enough questions to find some with images
 	limit := 100

--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,68 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}
+
+provider "registry.terraform.io/kislerdm/neon" {
+  version     = "0.13.0"
+  constraints = "~> 0.6"
+  hashes = [
+    "h1:bS35UCi8zj2vnHjoPFaKkENjKJ7Cp8oxkziDZDRTeDI=",
+    "zh:181663a962dbe8438e82bac6b507dd491de7a8b0718d072cbf9b77e4b13a3bb6",
+    "zh:296dd7c53b8bedcbf2eb8ab249ef555ec8d276cded1c9ca96d1db92964d99bdd",
+    "zh:2aafc4ed6f0c736b20305536edfc6c3720aef5b0b41827d3e66bf05f2f1777ab",
+    "zh:2dcde348d91e9cb07baefec9878263bcc17541494d7860c67c1d927899458385",
+    "zh:3f3fd6032179d65f0f30bfbf5c383c553e2bb90422fe8525d05eda4d257ea8e2",
+    "zh:3fb2bb0df0d484e321e5f45a90811ce5afe1b703cc86732201bcae73b810ea5d",
+    "zh:62fd5baddcac3d23a3ac7f70161cd18ce7aac666cc3415d28371ce7e434dcd10",
+    "zh:65a3fd55961c2a02fd6f8706176596cceb913f78455b9cc95fea66784e35b294",
+    "zh:854d2280e73e7cfc1e6ce5ace437e8b2fd7df1ea08f8b394b81b4beafe63cbdf",
+    "zh:97375d969f1842b85503840d31b1a1a3728bb08680f6159ca7170fb04217ca1e",
+    "zh:dc507119df3bde821c979e9022d49102aa5b2a1eca41bb9daa2536a7f45dcc26",
+    "zh:df587ce49ee519f483582b433eb783c4e434f23ba713c089ddac2f31996e458a",
+    "zh:edad18dbc7ee1c41a0dd3a4942787cfd51d9bcf3d73c6eac725f87457393aeef",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:ff2226223b9df1b6d673b8602d11a60e5217d5b3507250df1f4e3f00f3a3f1bb",
+  ]
+}

--- a/terraform/environments/prod/admin_api.tf
+++ b/terraform/environments/prod/admin_api.tf
@@ -1,0 +1,38 @@
+# S3 access for Admin API Lambda (Presigned URL generation)
+resource "aws_iam_role_policy" "lambda_admin_s3_presign" {
+  name   = "s3-presign-access"
+  role   = module.lambda_admin.role_name
+  policy = data.aws_iam_policy_document.lambda_admin_s3_presign.json
+}
+
+data "aws_iam_policy_document" "lambda_admin_s3_presign" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${module.image_s3.bucket_arn}/*",
+    ]
+  }
+}
+
+# S3 access for Admin API Lambda (Content JSON publish)
+resource "aws_iam_role_policy" "lambda_admin_s3_content" {
+  name   = "s3-content-access"
+  role   = module.lambda_admin.role_name
+  policy = data.aws_iam_policy_document.lambda_admin_s3_content.json
+}
+
+data "aws_iam_policy_document" "lambda_admin_s3_content" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${module.content_s3.bucket_arn}/*",
+    ]
+  }
+}

--- a/terraform/environments/prod/admin_frontend.tf
+++ b/terraform/environments/prod/admin_frontend.tf
@@ -1,0 +1,243 @@
+data "aws_ssm_parameter" "admin_basic_auth_user" {
+  name = "/rikako/admin-basic-auth-user"
+}
+
+data "aws_ssm_parameter" "admin_basic_auth_password" {
+  name = "/rikako/admin-basic-auth-password"
+}
+
+locals {
+  admin_bucket_name            = "${local.project}-admin-${local.environment}"
+  admin_api_origin_domain      = trimsuffix(trimprefix(module.lambda_admin.function_url, "https://"), "/")
+  admin_basic_auth_credentials = base64encode("${data.aws_ssm_parameter.admin_basic_auth_user.value}:${data.aws_ssm_parameter.admin_basic_auth_password.value}")
+}
+
+# S3 Bucket for admin frontend
+module "admin_s3" {
+  source = "../../modules/s3"
+
+  bucket_name = local.admin_bucket_name
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# CloudFront OAC for admin frontend (S3)
+resource "aws_cloudfront_origin_access_control" "admin" {
+  name                              = local.admin_bucket_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFront OAC for admin API (Lambda)
+resource "aws_cloudfront_origin_access_control" "admin_api" {
+  name                              = "${local.project}-admin-api-${local.environment}"
+  origin_access_control_origin_type = "lambda"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFront Function for Basic Auth + SPA rewrite (frontend)
+resource "aws_cloudfront_function" "admin_spa_rewrite" {
+  name    = "${local.project}-admin-spa-rewrite-${local.environment}"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = <<-EOF
+    var CREDENTIALS = '${local.admin_basic_auth_credentials}';
+    function handler(event) {
+      var request = event.request;
+      var headers = request.headers;
+      var auth = headers.authorization;
+      if (!auth || auth.value !== 'Basic ' + CREDENTIALS) {
+        return {
+          statusCode: 401,
+          statusDescription: 'Unauthorized',
+          headers: { 'www-authenticate': { value: 'Basic realm="Admin"' } },
+        };
+      }
+      var uri = request.uri;
+      if (uri.endsWith('/')) {
+        request.uri = uri + 'index.html';
+      } else if (!uri.includes('.')) {
+        var segments = uri.split('/').filter(function(s) { return s; });
+        if (segments.length > 1) {
+          request.uri = '/' + segments[0] + '/index.html';
+        } else {
+          request.uri = uri + '/index.html';
+        }
+      }
+      return request;
+    }
+  EOF
+}
+
+# CloudFront Function for Basic Auth + API rewrite
+resource "aws_cloudfront_function" "admin_api_auth_rewrite" {
+  name    = "${local.project}-admin-api-auth-rewrite-${local.environment}"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = <<-EOF
+    var CREDENTIALS = '${local.admin_basic_auth_credentials}';
+    function handler(event) {
+      var request = event.request;
+      var headers = request.headers;
+      var auth = headers.authorization;
+      if (!auth || auth.value !== 'Basic ' + CREDENTIALS) {
+        return {
+          statusCode: 401,
+          statusDescription: 'Unauthorized',
+          headers: { 'www-authenticate': { value: 'Basic realm="Admin"' } },
+        };
+      }
+      // OAC SigV4署名と競合するため、Basic Auth確認後にAuthorizationヘッダーを削除
+      delete request.headers.authorization;
+      request.uri = request.uri.replace(/^\/api/, '');
+      if (request.uri === '') {
+        request.uri = '/';
+      }
+      return request;
+    }
+  EOF
+}
+
+# CloudFront Distribution for admin (frontend + API)
+resource "aws_cloudfront_distribution" "admin" {
+  # Origin 1: S3 (frontend static files)
+  origin {
+    domain_name              = module.admin_s3.bucket_regional_domain_name
+    origin_id                = "s3-${local.admin_bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.admin.id
+  }
+
+  # Origin 2: Lambda Function URL (admin API) with OAC
+  origin {
+    domain_name              = local.admin_api_origin_domain
+    origin_id                = "lambda-admin-api"
+    origin_access_control_id = aws_cloudfront_origin_access_control.admin_api.id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Admin (frontend + API) for ${local.project}-${local.environment}"
+  default_root_object = "index.html"
+  aliases             = ["admin.rikako.jp"]
+
+  # Default: S3 frontend
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-${local.admin_bucket_name}"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 86400
+    max_ttl     = 31536000
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.admin_spa_rewrite.arn
+    }
+  }
+
+  # /api/* → Lambda admin API (with path rewrite)
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "lambda-admin-api"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.admin_api_auth_rewrite.arn
+    }
+  }
+
+  # SPA: return index.html for 403/404 (client-side routing)
+  custom_error_response {
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.wildcard.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# Lambda Permission - Allow CloudFront to invoke admin API via OAC
+resource "aws_lambda_permission" "admin_cloudfront" {
+  statement_id  = "AllowCloudFrontInvoke"
+  action        = "lambda:InvokeFunctionUrl"
+  function_name = module.lambda_admin.function_name
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.admin.arn
+}
+
+# S3 Bucket Policy - Allow CloudFront access via OAC
+resource "aws_s3_bucket_policy" "admin_cdn" {
+  bucket = module.admin_s3.bucket_id
+  policy = data.aws_iam_policy_document.admin_cdn_s3_access.json
+}
+
+data "aws_iam_policy_document" "admin_cdn_s3_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${module.admin_s3.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.admin.arn]
+    }
+  }
+}

--- a/terraform/environments/prod/cloudwatch.tf
+++ b/terraform/environments/prod/cloudwatch.tf
@@ -1,0 +1,182 @@
+# =============================================================================
+# CloudWatch Dashboard
+# =============================================================================
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${local.project}-${local.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      # --- Public API ---
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "# Public API (${module.lambda.function_name})"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 1
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Invocations"
+          region = var.region
+          stat   = "Sum"
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "Invocations", "FunctionName", module.lambda.function_name],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 1
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Duration (ms)"
+          region = var.region
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "Duration", "FunctionName", module.lambda.function_name, { stat = "Average" }],
+            ["...", { stat = "p99" }],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 1
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Errors / Throttles"
+          region = var.region
+          stat   = "Sum"
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "Errors", "FunctionName", module.lambda.function_name],
+            ["AWS/Lambda", "Throttles", "FunctionName", module.lambda.function_name],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 7
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Concurrent Executions"
+          region = var.region
+          stat   = "Maximum"
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "ConcurrentExecutions", "FunctionName", module.lambda.function_name],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 7
+        width  = 12
+        height = 6
+        properties = {
+          title  = "API Gateway (4xx / 5xx)"
+          region = var.region
+          stat   = "Sum"
+          period = 300
+          metrics = [
+            ["AWS/ApiGateway", "4xx", "ApiId", module.api_gateway.api_id],
+            ["AWS/ApiGateway", "5xx", "ApiId", module.api_gateway.api_id],
+          ]
+        }
+      },
+
+      # --- Admin API ---
+      {
+        type   = "text"
+        x      = 0
+        y      = 13
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "# Admin API (${module.lambda_admin.function_name})"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 14
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Invocations"
+          region = var.region
+          stat   = "Sum"
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "Invocations", "FunctionName", module.lambda_admin.function_name],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 14
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Duration (ms)"
+          region = var.region
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "Duration", "FunctionName", module.lambda_admin.function_name, { stat = "Average" }],
+            ["...", { stat = "p99" }],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 14
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Errors / Throttles"
+          region = var.region
+          stat   = "Sum"
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "Errors", "FunctionName", module.lambda_admin.function_name],
+            ["AWS/Lambda", "Throttles", "FunctionName", module.lambda_admin.function_name],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 20
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Concurrent Executions"
+          region = var.region
+          stat   = "Maximum"
+          period = 300
+          metrics = [
+            ["AWS/Lambda", "ConcurrentExecutions", "FunctionName", module.lambda_admin.function_name],
+          ]
+        }
+      },
+    ]
+  })
+}

--- a/terraform/environments/prod/cognito.tf
+++ b/terraform/environments/prod/cognito.tf
@@ -1,0 +1,22 @@
+module "cognito" {
+  source         = "../../modules/cognito"
+  user_pool_name = "${local.project}-${local.environment}"
+  client_name    = "${local.project}-mobile-${local.environment}"
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+module "cognito_identity" {
+  source             = "../../modules/cognito_identity"
+  identity_pool_name = "${local.project}-${local.environment}"
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}

--- a/terraform/environments/prod/content_cdn.tf
+++ b/terraform/environments/prod/content_cdn.tf
@@ -1,0 +1,61 @@
+locals {
+  content_bucket_name = "${local.project}-content-${local.environment}"
+}
+
+# S3 Bucket for content JSON
+module "content_s3" {
+  source = "../../modules/s3"
+
+  bucket_name = local.content_bucket_name
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# CloudFront for content delivery
+module "content_cloudfront" {
+  source = "../../modules/cloudfront"
+
+  name                = local.content_bucket_name
+  origin_domain_name  = module.content_s3.bucket_regional_domain_name
+  origin_id           = "s3-${local.content_bucket_name}"
+  comment             = "Content CDN for ${local.content_bucket_name}"
+  aliases             = ["content.rikako.jp"]
+  acm_certificate_arn = aws_acm_certificate_validation.wildcard.certificate_arn
+  default_ttl         = 60
+  max_ttl             = 300
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# S3 Bucket Policy - Allow CloudFront access via OAC
+resource "aws_s3_bucket_policy" "content_cdn" {
+  bucket = module.content_s3.bucket_id
+  policy = data.aws_iam_policy_document.content_cdn_s3_access.json
+}
+
+data "aws_iam_policy_document" "content_cdn_s3_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${module.content_s3.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.content_cloudfront.distribution_arn]
+    }
+  }
+}

--- a/terraform/environments/prod/dns.tf
+++ b/terraform/environments/prod/dns.tf
@@ -1,0 +1,131 @@
+# =============================================================================
+# Route 53 Hosted Zone for rikako.jp
+# 注意: rikako.jp ゾーンがすでに存在する場合は import が必要:
+#   terraform import aws_route53_zone.prod <ZONE_ID>
+# =============================================================================
+
+resource "aws_route53_zone" "prod" {
+  name = "rikako.jp"
+}
+
+# =============================================================================
+# ACM Wildcard Certificate (us-east-1, required for CloudFront)
+# =============================================================================
+
+resource "aws_acm_certificate" "wildcard" {
+  provider          = aws.us_east_1
+  domain_name       = "*.rikako.jp"
+  validation_method = "DNS"
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.wildcard.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = aws_route53_zone.prod.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 300
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "wildcard" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.wildcard.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# =============================================================================
+# ACM Wildcard Certificate (ap-northeast-1, required for API Gateway)
+# =============================================================================
+
+resource "aws_acm_certificate" "wildcard_regional" {
+  domain_name       = "*.rikako.jp"
+  validation_method = "DNS"
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "wildcard_regional" {
+  certificate_arn         = aws_acm_certificate.wildcard_regional.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# =============================================================================
+# Route 53 Records
+# =============================================================================
+
+# api.rikako.jp → API Gateway
+resource "aws_route53_record" "api" {
+  zone_id = aws_route53_zone.prod.zone_id
+  name    = "api.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = module.api_gateway.custom_domain_target
+    zone_id                = module.api_gateway.custom_domain_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# image.rikako.jp → Image CDN CloudFront
+resource "aws_route53_record" "image" {
+  zone_id = aws_route53_zone.prod.zone_id
+  name    = "image.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = module.image_cloudfront.domain_name
+    zone_id                = "Z2FDTNDATAQYW2" # CloudFront global hosted zone ID
+    evaluate_target_health = false
+  }
+}
+
+# content.rikako.jp → Content CDN CloudFront
+resource "aws_route53_record" "content" {
+  zone_id = aws_route53_zone.prod.zone_id
+  name    = "content.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = module.content_cloudfront.domain_name
+    zone_id                = "Z2FDTNDATAQYW2" # CloudFront global hosted zone ID
+    evaluate_target_health = false
+  }
+}
+
+# admin.rikako.jp → Admin Frontend CloudFront
+resource "aws_route53_record" "admin" {
+  zone_id = aws_route53_zone.prod.zone_id
+  name    = "admin.rikako.jp"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.admin.domain_name
+    zone_id                = aws_cloudfront_distribution.admin.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/environments/prod/github_actions.tf
+++ b/terraform/environments/prod/github_actions.tf
@@ -1,0 +1,155 @@
+# OIDC Provider for GitHub Actions
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [var.github_actions_oidc_thumbprint]
+}
+
+# Assume Role Policy for GitHub Actions
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:takoikatakotako/rikako:*"]
+    }
+  }
+}
+
+# IAM Role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name               = "${local.project}-${local.environment}-github-actions"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# ECR Access Policy (shared account)
+data "aws_iam_policy_document" "ecr_access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload"
+    ]
+    resources = [
+      "arn:aws:ecr:${var.region}:579039992557:repository/rikako-api",
+      "arn:aws:ecr:${var.region}:579039992557:repository/rikako-admin-api"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ecr_access" {
+  name   = "ecr-access"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.ecr_access.json
+}
+
+# Lambda deploy access
+resource "aws_iam_role_policy" "github_actions_lambda_deploy" {
+  name   = "lambda-deploy-access"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_lambda_deploy.json
+}
+
+data "aws_iam_policy_document" "github_actions_lambda_deploy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunction",
+    ]
+    resources = [
+      "arn:aws:lambda:${var.region}:${data.aws_caller_identity.current.account_id}:function:${local.project}-api-${local.environment}",
+      "arn:aws:lambda:${var.region}:${data.aws_caller_identity.current.account_id}:function:${local.project}-admin-api-${local.environment}",
+    ]
+  }
+}
+
+# Admin frontend S3 deploy + CloudFront invalidation
+resource "aws_iam_role_policy" "github_actions_admin_frontend" {
+  name   = "admin-frontend-deploy"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_admin_frontend.json
+}
+
+data "aws_iam_policy_document" "github_actions_admin_frontend" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.admin_s3.bucket_arn,
+      "${module.admin_s3.bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation",
+    ]
+    resources = [
+      aws_cloudfront_distribution.admin.arn,
+    ]
+  }
+}
+
+# SSM read access (for smoke tests)
+resource "aws_iam_role_policy" "github_actions_ssm" {
+  name   = "ssm-read-access"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_ssm.json
+}
+
+data "aws_iam_policy_document" "github_actions_ssm" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/rikako/admin-basic-auth-user",
+      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/rikako/admin-basic-auth-password",
+    ]
+  }
+}
+
+# Data source for current AWS account ID
+data "aws_caller_identity" "current" {}

--- a/terraform/environments/prod/image_cdn.tf
+++ b/terraform/environments/prod/image_cdn.tf
@@ -1,0 +1,82 @@
+locals {
+  image_bucket_name = "${local.project}-images-${local.environment}"
+}
+
+# S3 Bucket for images
+module "image_s3" {
+  source = "../../modules/s3"
+
+  bucket_name = local.image_bucket_name
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# CloudFront for image delivery
+module "image_cloudfront" {
+  source = "../../modules/cloudfront"
+
+  name                = local.image_bucket_name
+  origin_domain_name  = module.image_s3.bucket_regional_domain_name
+  origin_id           = "s3-${local.image_bucket_name}"
+  comment             = "Image CDN for ${local.image_bucket_name}"
+  aliases             = ["image.rikako.jp"]
+  acm_certificate_arn = aws_acm_certificate_validation.wildcard.certificate_arn
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# S3 Bucket Policy - Allow CloudFront access via OAC
+resource "aws_s3_bucket_policy" "image_cdn" {
+  bucket = module.image_s3.bucket_id
+  policy = data.aws_iam_policy_document.image_cdn_s3_access.json
+}
+
+data "aws_iam_policy_document" "image_cdn_s3_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${module.image_s3.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.image_cloudfront.distribution_arn]
+    }
+  }
+}
+
+# GitHub Actions - S3 image upload access
+resource "aws_iam_role_policy" "github_actions_s3_images" {
+  name   = "s3-images-access"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_s3_images.json
+}
+
+data "aws_iam_policy_document" "github_actions_s3_images" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.image_s3.bucket_arn,
+      "${module.image_s3.bucket_arn}/*",
+    ]
+  }
+}

--- a/terraform/environments/prod/lambda/slack_notifier/index.py
+++ b/terraform/environments/prod/lambda/slack_notifier/index.py
@@ -1,0 +1,58 @@
+"""CloudWatch アラームの SNS 通知を Slack Incoming Webhook へ転送する。"""
+import json
+import os
+import urllib.request
+
+WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]
+
+
+def handler(event, _context):
+    for record in event.get("Records", []):
+        sns = record.get("Sns", {})
+        raw = sns.get("Message", "")
+        try:
+            message = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            message = None
+
+        if isinstance(message, dict) and "AlarmName" in message:
+            text = format_alarm(message)
+        else:
+            subject = sns.get("Subject") or "Notification"
+            text = f"*{subject}*\n```{raw}```"
+
+        post_to_slack(text)
+
+
+def format_alarm(m: dict) -> str:
+    name = m.get("AlarmName", "Alarm")
+    state = m.get("NewStateValue", "")
+    reason = m.get("NewStateReason", "")
+    region = m.get("Region", "")
+    desc = m.get("AlarmDescription") or ""
+
+    emoji = {
+        "ALARM": ":rotating_light:",
+        "OK": ":white_check_mark:",
+        "INSUFFICIENT_DATA": ":grey_question:",
+    }.get(state, ":bell:")
+
+    parts = [f"{emoji} *{name}* — `{state}`"]
+    if desc:
+        parts.append(desc)
+    parts.append(reason)
+    if region:
+        parts.append(f"Region: {region}")
+    return "\n".join(parts)
+
+
+def post_to_slack(text: str) -> None:
+    body = json.dumps({"text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        WEBHOOK_URL,
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        if resp.status >= 400:
+            raise RuntimeError(f"slack returned {resp.status}: {resp.read()!r}")

--- a/terraform/environments/prod/locals.tf
+++ b/terraform/environments/prod/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  environment = "production"
+  project     = "rikako"
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,116 @@
+# =============================================================================
+# OpenAI APIキー
+# =============================================================================
+# 事前準備: OpenAI APIキーを SSM Parameter Store に SecureString で保存
+#   aws ssm put-parameter --name /rikako/production/openai-api-key \
+#     --value 'sk-...' --type SecureString
+# =============================================================================
+
+data "aws_ssm_parameter" "openai_api_key" {
+  name            = "/${local.project}/${local.environment}/openai-api-key"
+  with_decryption = true
+}
+
+# =============================================================================
+# Slack Webhook URL（お問い合わせ通知用）
+# =============================================================================
+# 事前準備: Slack Webhook URLを SSM Parameter Store に SecureString で保存
+#   aws ssm put-parameter --name /rikako/production/slack-contact-webhook-url \
+#     --value 'https://hooks.slack.com/services/...' --type SecureString
+# =============================================================================
+
+data "aws_ssm_parameter" "slack_contact_webhook_url" {
+  name            = "/${local.project}/${local.environment}/slack-contact-webhook-url"
+  with_decryption = true
+}
+
+# Lambda Function (Public API)
+module "lambda" {
+  source = "../../modules/lambda"
+
+  function_name = "${local.project}-api-${local.environment}"
+  image_uri     = "579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-api:prod"
+  architectures = ["arm64"]
+  timeout       = 30
+  memory_size   = 512
+
+  cognito_identity_pool_arn = module.cognito_identity.identity_pool_arn
+
+  environment_variables = {
+    DATABASE_URL                     = neon_project.default.connection_uri
+    PORT                             = "8080"
+    ENVIRONMENT                      = local.environment
+    IMAGE_BASE_URL                   = "https://${module.image_cloudfront.domain_name}"
+    AWS_LWA_READINESS_CHECK_PROTOCOL = "http"
+    AWS_LWA_READINESS_CHECK_PORT     = "8080"
+    AWS_LWA_READINESS_CHECK_PATH     = "/health"
+    COGNITO_USER_POOL_ID             = module.cognito.user_pool_id
+    COGNITO_REGION                   = "ap-northeast-1"
+    COGNITO_IDENTITY_POOL_ID         = module.cognito_identity.identity_pool_id
+    MINIMUM_VERSION                  = "1.0.0"
+    LATEST_VERSION                   = "1.0.0"
+    OPENAI_API_KEY                   = data.aws_ssm_parameter.openai_api_key.value
+    SLACK_WEBHOOK_URL                = data.aws_ssm_parameter.slack_contact_webhook_url.value
+  }
+
+  create_function_url = false
+  log_retention_days  = 30
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# API Gateway HTTP API (Public API)
+module "api_gateway" {
+  source = "../../modules/api_gateway"
+
+  name                 = "${local.project}-api-${local.environment}"
+  lambda_function_name = module.lambda.function_name
+  lambda_invoke_arn    = module.lambda.invoke_arn
+  custom_domain_name   = "api.rikako.jp"
+  acm_certificate_arn  = aws_acm_certificate_validation.wildcard_regional.certificate_arn
+  throttle_burst_limit = 200
+  throttle_rate_limit  = 100
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# Lambda Function (Admin API)
+module "lambda_admin" {
+  source = "../../modules/lambda"
+
+  function_name          = "${local.project}-admin-api-${local.environment}"
+  function_url_auth_type = "AWS_IAM"
+  image_uri              = "579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-admin-api:prod"
+  architectures          = ["arm64"]
+  timeout                = 30
+  memory_size            = 512
+
+  environment_variables = {
+    DATABASE_URL                     = neon_project.default.connection_uri
+    PORT                             = "8080"
+    ENVIRONMENT                      = local.environment
+    IMAGE_BASE_URL                   = "https://${module.image_cloudfront.domain_name}"
+    IMAGE_S3_BUCKET                  = local.image_bucket_name
+    CONTENT_S3_BUCKET                = local.content_bucket_name
+    CONTENT_BASE_URL                 = "https://content.rikako.jp"
+    AWS_LWA_READINESS_CHECK_PROTOCOL = "http"
+    AWS_LWA_READINESS_CHECK_PORT     = "8080"
+    AWS_LWA_READINESS_CHECK_PATH     = "/health"
+  }
+
+  log_retention_days = 30
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}

--- a/terraform/environments/prod/monitoring.tf
+++ b/terraform/environments/prod/monitoring.tf
@@ -1,0 +1,212 @@
+# =============================================================================
+# Slack 通知
+# =============================================================================
+# 事前準備: Slack Incoming Webhook URL を SSM Parameter Store に SecureString で保存
+#   aws ssm put-parameter --name /rikako/production/slack-alert-webhook-url \
+#     --value 'https://hooks.slack.com/services/...' --type SecureString
+# =============================================================================
+
+data "aws_ssm_parameter" "slack_alert_webhook_url" {
+  name            = "/${local.project}/${local.environment}/slack-alert-webhook-url"
+  with_decryption = true
+}
+
+resource "aws_sns_topic" "alerts" {
+  name = "${local.project}-alerts-${local.environment}"
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# --- Slack 通知 Lambda ---
+
+data "archive_file" "slack_notifier" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/slack_notifier"
+  output_path = "${path.module}/lambda/slack_notifier.zip"
+}
+
+resource "aws_iam_role" "slack_notifier" {
+  name = "${local.project}-slack-notifier-${local.environment}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "slack_notifier_logs" {
+  role       = aws_iam_role.slack_notifier.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_cloudwatch_log_group" "slack_notifier" {
+  name              = "/aws/lambda/${local.project}-slack-notifier-${local.environment}"
+  retention_in_days = 30
+}
+
+resource "aws_lambda_function" "slack_notifier" {
+  function_name    = "${local.project}-slack-notifier-${local.environment}"
+  role             = aws_iam_role.slack_notifier.arn
+  runtime          = "python3.13"
+  handler          = "index.handler"
+  filename         = data.archive_file.slack_notifier.output_path
+  source_code_hash = data.archive_file.slack_notifier.output_base64sha256
+  timeout          = 10
+  memory_size      = 128
+
+  environment {
+    variables = {
+      SLACK_WEBHOOK_URL = data.aws_ssm_parameter.slack_alert_webhook_url.value
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.slack_notifier]
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_lambda_permission" "allow_sns_invoke" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_notifier.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.alerts.arn
+}
+
+resource "aws_sns_topic_subscription" "slack" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.slack_notifier.arn
+}
+
+# =============================================================================
+# CloudWatch Alarms
+# =============================================================================
+
+locals {
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  alarm_tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# --- Public API ---
+
+resource "aws_cloudwatch_metric_alarm" "public_api_errors" {
+  alarm_name          = "${local.project}-${local.environment}-public-api-errors"
+  alarm_description   = "Public API Lambda が 5分間で 5 件以上エラーを出した"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { FunctionName = module.lambda.function_name }
+  alarm_actions       = local.alarm_actions
+  ok_actions          = local.alarm_actions
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "public_api_throttles" {
+  alarm_name          = "${local.project}-${local.environment}-public-api-throttles"
+  alarm_description   = "Public API Lambda がスロットリングされた"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Throttles"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { FunctionName = module.lambda.function_name }
+  alarm_actions       = local.alarm_actions
+  ok_actions          = local.alarm_actions
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "public_api_p99_latency" {
+  alarm_name          = "${local.project}-${local.environment}-public-api-p99-latency"
+  alarm_description   = "Public API Lambda の p99 レイテンシが 10 秒を超えた"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Duration"
+  extended_statistic  = "p99"
+  period              = 300
+  evaluation_periods  = 2
+  threshold           = 10000
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { FunctionName = module.lambda.function_name }
+  alarm_actions       = local.alarm_actions
+  ok_actions          = local.alarm_actions
+  tags                = local.alarm_tags
+}
+
+# --- Admin API ---
+
+resource "aws_cloudwatch_metric_alarm" "admin_api_errors" {
+  alarm_name          = "${local.project}-${local.environment}-admin-api-errors"
+  alarm_description   = "Admin API Lambda が 5分間で 1 件以上エラーを出した"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { FunctionName = module.lambda_admin.function_name }
+  alarm_actions       = local.alarm_actions
+  ok_actions          = local.alarm_actions
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_api_throttles" {
+  alarm_name          = "${local.project}-${local.environment}-admin-api-throttles"
+  alarm_description   = "Admin API Lambda がスロットリングされた"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Throttles"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { FunctionName = module.lambda_admin.function_name }
+  alarm_actions       = local.alarm_actions
+  ok_actions          = local.alarm_actions
+  tags                = local.alarm_tags
+}
+
+# --- API Gateway (Public API) ---
+
+resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
+  alarm_name          = "${local.project}-${local.environment}-api-gateway-5xx"
+  alarm_description   = "API Gateway が 5分間で 5 件以上の 5xx を返した"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "5xx"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { ApiId = module.api_gateway.api_id }
+  alarm_actions       = local.alarm_actions
+  ok_actions          = local.alarm_actions
+  tags                = local.alarm_tags
+}

--- a/terraform/environments/prod/neon.tf
+++ b/terraform/environments/prod/neon.tf
@@ -1,0 +1,31 @@
+# Neon Project
+resource "neon_project" "default" {
+  name                      = "${local.project}-${local.environment}"
+  region_id                 = "aws-ap-southeast-1" # Singapore
+  history_retention_seconds = 21600                # 6 hours (plan maximum)
+
+  default_endpoint_settings {
+    autoscaling_limit_min_cu = 0.25
+    autoscaling_limit_max_cu = 4
+    suspend_timeout_seconds  = 0 # Always active (no auto-suspend)
+  }
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+# Role
+resource "neon_role" "default" {
+  project_id = neon_project.default.id
+  branch_id  = neon_project.default.default_branch_id
+  name       = "rikako_owner"
+}
+
+# Database
+resource "neon_database" "default" {
+  project_id = neon_project.default.id
+  branch_id  = neon_project.default.default_branch_id
+  name       = "rikako"
+  owner_name = neon_role.default.name
+}

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -1,0 +1,67 @@
+output "database_host" {
+  description = "Neon database host"
+  value       = neon_project.default.database_host
+  sensitive   = true
+}
+
+output "connection_string" {
+  description = "Database connection string"
+  value       = neon_project.default.connection_uri
+  sensitive   = true
+}
+
+output "api_endpoint" {
+  description = "URL of the public API"
+  value       = "https://api.rikako.jp"
+}
+
+output "api_gateway_id" {
+  description = "API Gateway HTTP API ID"
+  value       = module.api_gateway.api_id
+}
+
+output "admin_function_url" {
+  description = "URL of the admin API Lambda function"
+  value       = module.lambda_admin.function_url
+}
+
+
+output "github_actions_role_arn" {
+  description = "ARN of the GitHub Actions IAM role"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = module.cognito.user_pool_id
+}
+
+output "cognito_user_pool_endpoint" {
+  description = "Cognito User Pool endpoint"
+  value       = module.cognito.user_pool_endpoint
+}
+
+output "cognito_client_id" {
+  description = "Cognito User Pool Client ID"
+  value       = module.cognito.client_id
+}
+
+output "admin_frontend_url" {
+  description = "URL of the admin frontend (CloudFront)"
+  value       = "https://${aws_cloudfront_distribution.admin.domain_name}"
+}
+
+output "admin_frontend_distribution_id" {
+  description = "CloudFront distribution ID for admin frontend"
+  value       = aws_cloudfront_distribution.admin.id
+}
+
+output "admin_frontend_bucket" {
+  description = "S3 bucket for admin frontend"
+  value       = module.admin_s3.bucket_id
+}
+
+output "prod_zone_name_servers" {
+  description = "Name servers for rikako.jp (set these as NS records at domain registrar if not managed by Route 53)"
+  value       = aws_route53_zone.prod.name_servers
+}

--- a/terraform/environments/prod/terraform.tf
+++ b/terraform/environments/prod/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "rikako-prod-terraform-state"
+    key          = "terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "github_actions_oidc_thumbprint" {
+  description = "GitHub Actions OIDCエンドポイント（token.actions.githubusercontent.com）のルートCA証明書のサムプリント。AWS側で独自に検証するため実質任意の値でも動作するが、慣習的にこの既知の値を使用する。"
+  type        = string
+  default     = "6938fd4d98bab03faadb97b34396831e3780aea1"
+}

--- a/terraform/environments/prod/versions.tf
+++ b/terraform/environments/prod/versions.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    neon = {
+      source  = "kislerdm/neon"
+      version = "~> 0.6"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+# CloudFront requires ACM certificates in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+data "aws_ssm_parameter" "neon_api_key" {
+  name = "/rikako/neon-api-key"
+}
+
+provider "neon" {
+  api_key = data.aws_ssm_parameter.neon_api_key.value
+}

--- a/terraform/environments/shared/locals.tf
+++ b/terraform/environments/shared/locals.tf
@@ -2,6 +2,6 @@ locals {
   environment = "shared"
   project     = "rikako"
 
-  # Dev環境のアカウントID（ECRへのアクセスを許可）
-  allowed_account_ids = ["197865631794"]
+  # Dev/Prod環境のアカウントID（ECRへのアクセスを許可）
+  allowed_account_ids = ["197865631794", "211125415945"]
 }


### PR DESCRIPTION
## Summary

- `terraform/environments/prod/` を新規作成（Lambda, API Gateway, Neon, Cognito, CloudFront, Route53, CloudWatch, Monitoring）
- `terraform/environments/shared/locals.tf` に prod アカウント（211125415945）を ECR `allowed_account_ids` に追加
- prod 用 GitHub Actions ワークフローを追加（手動トリガーのみ）

## 主要リソース

| リソース | 値 |
|---|---|
| 公開API | `https://api.rikako.jp` |
| 管理画面 | `https://admin.rikako.jp` |
| AWSアカウント | `211125415945` (rikako-production) |

## dev との主な違い

- ECR イメージタグ: `:prod`
- ログ保持: 30日（dev は 7日）
- API Gateway スロットル: burst 200 / rate 100（dev は 100 / 50）
- デプロイ: 手動トリガーのみ（dev は main push で自動）
- GitHub Actions Role: デプロイ権限のみ（AdministratorAccess なし）

## Test plan

- [x] `terraform plan` でエラーなし
- [x] `terraform apply` 成功
- [x] `api.rikako.jp` の Route53 レコード作成済み
- [ ] マイグレーション適用（別途 `migrate.yml` を prod 対応に拡張が必要）
- [ ] 初回デプロイワークフロー実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)