### PR TITLE
feat: prod GitHub Actions Role に Terraform state 読み取り権限を追加

### DIFF
--- a/terraform/environments/prod/github_actions.tf
+++ b/terraform/environments/prod/github_actions.tf
@@ -131,6 +131,27 @@ data "aws_iam_policy_document" "github_actions_admin_frontend" {
   }
 }
 
+# Terraform state read access (for migration workflow)
+resource "aws_iam_role_policy" "github_actions_terraform_state" {
+  name   = "terraform-state-read"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_terraform_state.json
+}
+
+data "aws_iam_policy_document" "github_actions_terraform_state" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::rikako-prod-terraform-state",
+      "arn:aws:s3:::rikako-prod-terraform-state/*",
+    ]
+  }
+}
+
 # SSM read access (for smoke tests)
 resource "aws_iam_role_policy" "github_actions_ssm" {
   name   = "ssm-read-access"


### PR DESCRIPTION
## Summary

- prod 環境の GitHub Actions IAM Role に Terraform state S3 の読み取り権限を追加
- `migrate-prod.yml` ワークフローが Terraform output から DB 接続文字列を取得するために必要

## Test plan

- [ ] `terraform apply` で権限が適用されることを確認
- [ ] `migrate-prod.yml` で DB 接続が成功することを確認（後続 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)