### PR TITLE
feat: migrate.yml を dev/prod 別ワークフローに分割

### DIFF
--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -1,0 +1,83 @@
+name: Run Database Migration (Dev)
+
+on:
+  workflow_dispatch:
+    inputs:
+      direction:
+        description: 'Migration direction'
+        required: true
+        default: 'up'
+        type: choice
+        options:
+          - up
+          - down
+      steps:
+        description: 'Number of steps (leave empty for all)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  migrate:
+    name: Run Migration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.14.0
+          terraform_wrapper: false
+
+      - name: Get database connection string
+        id: db-config
+        working-directory: terraform/environments/dev
+        env:
+          TF_VAR_neon_api_key: ${{ secrets.NEON_API_KEY }}
+        run: |
+          terraform init
+          CONNECTION_STRING=$(terraform output -raw connection_string)
+          echo "connection-string=${CONNECTION_STRING}" >> $GITHUB_OUTPUT
+          echo "::add-mask::${CONNECTION_STRING}"
+
+      - name: Run migration
+        run: |
+          MIGRATION_COMMAND="${{ github.event.inputs.direction }}"
+
+          if [ -n "${{ github.event.inputs.steps }}" ]; then
+            MIGRATION_COMMAND="${MIGRATION_COMMAND} ${{ github.event.inputs.steps }}"
+          fi
+
+          echo "Running migration: ${MIGRATION_COMMAND}"
+
+          docker run --rm -v $(pwd)/migrations:/migrations \
+            migrate/migrate -path=/migrations \
+            -database "${{ steps.db-config.outputs.connection-string }}" \
+            ${MIGRATION_COMMAND}
+
+      - name: Migration summary
+        if: always()
+        run: |
+          echo "## Migration Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** dev" >> $GITHUB_STEP_SUMMARY
+          echo "**Direction:** ${{ github.event.inputs.direction }}" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ github.event.inputs.steps }}" ]; then
+            echo "**Steps:** ${{ github.event.inputs.steps }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Steps:** All" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -1,15 +1,8 @@
-name: Run Database Migration
+name: Run Database Migration (Prod)
 
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Environment to run migration'
-        required: true
-        type: choice
-        options:
-          - dev
-          - prod
       direction:
         description: 'Migration direction'
         required: true
@@ -41,7 +34,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
@@ -52,7 +45,7 @@ jobs:
 
       - name: Get database connection string
         id: db-config
-        working-directory: terraform/environments/${{ github.event.inputs.environment }}
+        working-directory: terraform/environments/prod
         env:
           TF_VAR_neon_api_key: ${{ secrets.NEON_API_KEY }}
         run: |
@@ -81,7 +74,7 @@ jobs:
         run: |
           echo "## Migration Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** prod" >> $GITHUB_STEP_SUMMARY
           echo "**Direction:** ${{ github.event.inputs.direction }}" >> $GITHUB_STEP_SUMMARY
           if [ -n "${{ github.event.inputs.steps }}" ]; then
             echo "**Steps:** ${{ github.event.inputs.steps }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- `migrate.yml` を `migrate-dev.yml` と `migrate-prod.yml` に分割
- 環境の選択入力を廃止し、各ワークフローが対応する環境に固定
- 誤った環境へのマイグレーション実行を防止
- `migrate-prod.yml` は PR #184 で追加する IAM 権限（Terraform state 読み取り）が必要

## Changes

| ファイル | 変更 |
|---|---|
| `migrate.yml` | 削除 |
| `migrate-dev.yml` | 新規（dev 固定、dev IAM Role 使用） |
| `migrate-prod.yml` | 新規（prod 固定、prod IAM Role 使用） |

## Test plan

- [ ] PR #184 マージ後に prod の Terraform apply を実行
- [ ] `migrate-prod.yml` を dispatch して prod DB にマイグレーション適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)