### PR TITLE
fix: インポーターを Neon 接続リセットに対応

### DIFF
--- a/app/cmd/importer/main.go
+++ b/app/cmd/importer/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/takoikatakotako/rikako/internal/importer"
@@ -13,6 +14,7 @@ import (
 func main() {
 	dataDir := flag.String("data", "data", "データディレクトリのパス")
 	checkOnly := flag.Bool("check-only", false, "データベースの問題数を確認するのみ")
+	workbooksOnly := flag.Bool("workbooks-only", false, "workbooks/categoriesのみインポート（問題は既存のものを使用）")
 	flag.Parse()
 
 	// DB接続
@@ -26,6 +28,11 @@ func main() {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
 	defer db.Close()
+
+	// Neon のコネクションプロキシがアイドル接続をリセットするため短めに設定
+	db.SetMaxOpenConns(1)
+	db.SetConnMaxLifetime(30 * time.Second)
+	db.SetConnMaxIdleTime(10 * time.Second)
 
 	if err := db.Ping(); err != nil {
 		log.Fatalf("Failed to ping database: %v", err)
@@ -44,8 +51,14 @@ func main() {
 
 	// インポート実行
 	imp := importer.New(db, *dataDir)
-	if err := imp.Run(); err != nil {
-		log.Fatalf("Import failed: %v", err)
+	var importErr error
+	if *workbooksOnly {
+		importErr = imp.RunWorkbooksOnly()
+	} else {
+		importErr = imp.Run()
+	}
+	if importErr != nil {
+		log.Fatalf("Import failed: %v", importErr)
 	}
 
 	log.Println("Import completed successfully!")

--- a/app/internal/db/importer.sql.go
+++ b/app/internal/db/importer.sql.go
@@ -83,7 +83,7 @@ func (q *Queries) DeleteAllWorkbooks(ctx context.Context) error {
 }
 
 const importCategory = `-- name: ImportCategory :exec
-INSERT INTO categories (id, title, description) VALUES ($1, $2, $3)
+INSERT INTO categories (id, title, description) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
 `
 
 type ImportCategoryParams struct {
@@ -99,7 +99,7 @@ func (q *Queries) ImportCategory(ctx context.Context, arg ImportCategoryParams) 
 
 const importChoice = `-- name: ImportChoice :exec
 INSERT INTO questions_single_choice_choices (single_choice_id, choice_index, text, is_correct)
-VALUES ($1, $2, $3, $4)
+VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING
 `
 
 type ImportChoiceParams struct {
@@ -120,7 +120,7 @@ func (q *Queries) ImportChoice(ctx context.Context, arg ImportChoiceParams) erro
 }
 
 const importImage = `-- name: ImportImage :exec
-INSERT INTO images (id, path) VALUES ($1, $2)
+INSERT INTO images (id, path) VALUES ($1, $2) ON CONFLICT DO NOTHING
 `
 
 type ImportImageParams struct {
@@ -134,7 +134,7 @@ func (q *Queries) ImportImage(ctx context.Context, arg ImportImageParams) error 
 }
 
 const importQuestion = `-- name: ImportQuestion :exec
-INSERT INTO questions (id, type) VALUES ($1, $2)
+INSERT INTO questions (id, type) VALUES ($1, $2) ON CONFLICT DO NOTHING
 `
 
 type ImportQuestionParams struct {
@@ -148,7 +148,7 @@ func (q *Queries) ImportQuestion(ctx context.Context, arg ImportQuestionParams) 
 }
 
 const importQuestionImage = `-- name: ImportQuestionImage :exec
-INSERT INTO question_images (question_id, image_id, order_index) VALUES ($1, $2, $3)
+INSERT INTO question_images (question_id, image_id, order_index) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
 `
 
 type ImportQuestionImageParams struct {
@@ -164,7 +164,9 @@ func (q *Queries) ImportQuestionImage(ctx context.Context, arg ImportQuestionIma
 
 const importSingleChoice = `-- name: ImportSingleChoice :one
 INSERT INTO questions_single_choice (question_id, text, explanation)
-VALUES ($1, $2, $3) RETURNING id
+VALUES ($1, $2, $3)
+ON CONFLICT (question_id) DO UPDATE SET text = EXCLUDED.text, explanation = EXCLUDED.explanation
+RETURNING id
 `
 
 type ImportSingleChoiceParams struct {
@@ -181,7 +183,7 @@ func (q *Queries) ImportSingleChoice(ctx context.Context, arg ImportSingleChoice
 }
 
 const importWorkbook = `-- name: ImportWorkbook :exec
-INSERT INTO workbooks (id, title, description) VALUES ($1, $2, $3)
+INSERT INTO workbooks (id, title, description) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
 `
 
 type ImportWorkbookParams struct {
@@ -196,7 +198,7 @@ func (q *Queries) ImportWorkbook(ctx context.Context, arg ImportWorkbookParams) 
 }
 
 const importWorkbookQuestion = `-- name: ImportWorkbookQuestion :exec
-INSERT INTO workbook_questions (workbook_id, question_id, order_index) VALUES ($1, $2, $3)
+INSERT INTO workbook_questions (workbook_id, question_id, order_index) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
 `
 
 type ImportWorkbookQuestionParams struct {

--- a/app/internal/importer/importer.go
+++ b/app/internal/importer/importer.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/takoikatakotako/rikako/internal/db"
 	"gopkg.in/yaml.v3"
@@ -29,61 +31,102 @@ func New(d *sql.DB, dataDir string) *Importer {
 }
 
 func (i *Importer) Run() error {
+	return i.RunPhases(false)
+}
+
+func (i *Importer) RunWorkbooksOnly() error {
+	return i.RunPhases(true)
+}
+
+func (i *Importer) RunPhases(workbooksOnly bool) error {
 	ctx := context.Background()
 
-	// トランザクション開始
-	tx, err := i.sqlDB.Begin()
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+	if !workbooksOnly {
+		// フェーズ1: 既存データを削除
+		if err := i.runInTx(ctx, func(qtx *db.Queries, tx *sql.Tx) error {
+			return i.clearData(ctx, qtx)
+		}); err != nil {
+			return fmt.Errorf("failed to clear data: %w", err)
+		}
+
+		// フェーズ2: 画像をインポート
+		imageCount, err := i.importImages(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to import images: %w", err)
+		}
+		fmt.Printf("Imported %d images\n", imageCount)
+
+		// フェーズ3: 問題をインポート（1問ずつリトライ付き）
+		questionCount, err := i.importQuestions(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to import questions: %w", err)
+		}
+		fmt.Printf("Imported %d questions\n", questionCount)
 	}
-	defer tx.Rollback()
 
-	qtx := i.queries.WithTx(tx)
-
-	// 既存データを削除
-	if err := i.clearData(ctx, qtx); err != nil {
-		return fmt.Errorf("failed to clear data: %w", err)
-	}
-
-	// 画像をインポート
-	imageCount, err := i.importImages(ctx, qtx)
-	if err != nil {
-		return fmt.Errorf("failed to import images: %w", err)
-	}
-	fmt.Printf("Imported %d images\n", imageCount)
-
-	// 問題をインポート
-	questionCount, err := i.importQuestions(ctx, qtx)
-	if err != nil {
-		return fmt.Errorf("failed to import questions: %w", err)
-	}
-	fmt.Printf("Imported %d questions\n", questionCount)
-
-	// 問題集をインポート
-	workbookCount, err := i.importWorkbooks(ctx, qtx)
+	// フェーズ4: 問題集をインポート
+	workbookCount, err := i.importWorkbooks(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to import workbooks: %w", err)
 	}
 	fmt.Printf("Imported %d workbooks\n", workbookCount)
 
-	// カテゴリをインポート
-	categoryCount, err := i.importCategories(ctx, qtx)
+	// フェーズ5: カテゴリをインポート
+	categoryCount, err := i.importCategories(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to import categories: %w", err)
 	}
 	fmt.Printf("Imported %d categories\n", categoryCount)
 
-	// シーケンスをリセット（動的SQLのためraw SQL）
-	if err := i.resetSequences(tx); err != nil {
+	// フェーズ6: シーケンスをリセット
+	if err := i.runInTx(ctx, func(qtx *db.Queries, tx *sql.Tx) error {
+		return i.resetSequences(tx)
+	}); err != nil {
 		return fmt.Errorf("failed to reset sequences: %w", err)
 	}
 
-	// コミット
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit: %w", err)
-	}
-
 	return nil
+}
+
+func (i *Importer) runInTx(ctx context.Context, fn func(*db.Queries, *sql.Tx) error) error {
+	tx, err := i.sqlDB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := fn(i.queries.WithTx(tx), tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "EOF") ||
+		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "no connection")
+}
+
+func (i *Importer) runInTxWithRetry(ctx context.Context, fn func(*db.Queries, *sql.Tx) error) error {
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+		}
+		lastErr = i.runInTx(ctx, fn)
+		if lastErr == nil {
+			return nil
+		}
+		if !isRetryableError(lastErr) {
+			return lastErr
+		}
+	}
+	return lastErr
 }
 
 func (i *Importer) clearData(ctx context.Context, qtx *db.Queries) error {
@@ -105,102 +148,115 @@ func (i *Importer) clearData(ctx context.Context, qtx *db.Queries) error {
 	return nil
 }
 
-func (i *Importer) importImages(ctx context.Context, qtx *db.Queries) (int, error) {
+func (i *Importer) importImages(ctx context.Context) (int, error) {
 	files, err := filepath.Glob(filepath.Join(i.imageDir, "*.png"))
 	if err != nil {
 		return 0, err
 	}
 
 	count := 0
-	for _, file := range files {
-		filename := filepath.Base(file)
-		name := filename[:len(filename)-4] // .png を除去
+	err = i.runInTx(ctx, func(qtx *db.Queries, tx *sql.Tx) error {
+		for _, file := range files {
+			filename := filepath.Base(file)
+			name := filename[:len(filename)-4]
 
-		id, err := strconv.ParseInt(name, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid image filename %s: %w", filename, err)
+			id, err := strconv.ParseInt(name, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid image filename %s: %w", filename, err)
+			}
+
+			if err := qtx.ImportImage(ctx, db.ImportImageParams{
+				ID:   id,
+				Path: filename,
+			}); err != nil {
+				return fmt.Errorf("failed to insert image %s: %w", filename, err)
+			}
+			count++
 		}
-
-		if err := qtx.ImportImage(ctx, db.ImportImageParams{
-			ID:   id,
-			Path: filename,
-		}); err != nil {
-			return 0, fmt.Errorf("failed to insert image %s: %w", filename, err)
-		}
-
-		count++
-	}
-
-	return count, nil
+		return nil
+	})
+	return count, err
 }
 
-func (i *Importer) importQuestions(ctx context.Context, qtx *db.Queries) (int, error) {
+const questionBatchSize = 1
+
+func (i *Importer) importQuestions(ctx context.Context) (int, error) {
 	questionsDir := filepath.Join(i.dataDir, "questions")
 	files, err := filepath.Glob(filepath.Join(questionsDir, "*.yml"))
 	if err != nil {
 		return 0, err
 	}
 
-	count := 0
-	for _, file := range files {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return 0, fmt.Errorf("failed to read %s: %w", file, err)
+	total := 0
+	for start := 0; start < len(files); start += questionBatchSize {
+		end := start + questionBatchSize
+		if end > len(files) {
+			end = len(files)
 		}
+		batch := files[start:end]
 
-		var q QuestionYAML
-		if err := yaml.Unmarshal(data, &q); err != nil {
-			return 0, fmt.Errorf("failed to parse %s: %w", file, err)
-		}
+		err := i.runInTxWithRetry(ctx, func(qtx *db.Queries, tx *sql.Tx) error {
+			for _, file := range batch {
+				data, err := os.ReadFile(file)
+				if err != nil {
+					return fmt.Errorf("failed to read %s: %w", file, err)
+				}
 
-		// questions テーブルに挿入
-		if err := qtx.ImportQuestion(ctx, db.ImportQuestionParams{
-			ID:   q.ID,
-			Type: q.Type,
-		}); err != nil {
-			return 0, fmt.Errorf("failed to insert question %d: %w", q.ID, err)
-		}
+				var q QuestionYAML
+				if err := yaml.Unmarshal(data, &q); err != nil {
+					return fmt.Errorf("failed to parse %s: %w", file, err)
+				}
 
-		// questions_single_choice テーブルに挿入
-		singleChoiceID, err := qtx.ImportSingleChoice(ctx, db.ImportSingleChoiceParams{
-			QuestionID:  q.ID,
-			Text:        q.Text,
-			Explanation: sql.NullString{String: q.Explanation, Valid: q.Explanation != ""},
+				if err := qtx.ImportQuestion(ctx, db.ImportQuestionParams{
+					ID:   q.ID,
+					Type: q.Type,
+				}); err != nil {
+					return fmt.Errorf("failed to insert question %d: %w", q.ID, err)
+				}
+
+				singleChoiceID, err := qtx.ImportSingleChoice(ctx, db.ImportSingleChoiceParams{
+					QuestionID:  q.ID,
+					Text:        q.Text,
+					Explanation: sql.NullString{String: q.Explanation, Valid: q.Explanation != ""},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to insert single_choice %d: %w", q.ID, err)
+				}
+
+				for idx, choice := range q.Choices {
+					if err := qtx.ImportChoice(ctx, db.ImportChoiceParams{
+						SingleChoiceID: singleChoiceID,
+						ChoiceIndex:    int32(idx),
+						Text:           choice,
+						IsCorrect:      idx == q.Correct,
+					}); err != nil {
+						return fmt.Errorf("failed to insert choice for %d: %w", q.ID, err)
+					}
+				}
+
+				for idx, imageID := range q.Images {
+					if err := qtx.ImportQuestionImage(ctx, db.ImportQuestionImageParams{
+						QuestionID: q.ID,
+						ImageID:    imageID,
+						OrderIndex: int32(idx),
+					}); err != nil {
+						return fmt.Errorf("failed to link image for %d: %w", q.ID, err)
+					}
+				}
+			}
+			return nil
 		})
 		if err != nil {
-			return 0, fmt.Errorf("failed to insert single_choice %d: %w", q.ID, err)
+			return 0, err
 		}
-
-		// 選択肢を挿入
-		for idx, choice := range q.Choices {
-			if err := qtx.ImportChoice(ctx, db.ImportChoiceParams{
-				SingleChoiceID: singleChoiceID,
-				ChoiceIndex:    int32(idx),
-				Text:           choice,
-				IsCorrect:      idx == q.Correct,
-			}); err != nil {
-				return 0, fmt.Errorf("failed to insert choice for %d: %w", q.ID, err)
-			}
-		}
-
-		// 画像を紐付け
-		for idx, imageID := range q.Images {
-			if err := qtx.ImportQuestionImage(ctx, db.ImportQuestionImageParams{
-				QuestionID: q.ID,
-				ImageID:    imageID,
-				OrderIndex: int32(idx),
-			}); err != nil {
-				return 0, fmt.Errorf("failed to link image for %d: %w", q.ID, err)
-			}
-		}
-
-		count++
+		total += len(batch)
+		fmt.Printf("  questions %d/%d\n", total, len(files))
 	}
 
-	return count, nil
+	return total, nil
 }
 
-func (i *Importer) importWorkbooks(ctx context.Context, qtx *db.Queries) (int, error) {
+func (i *Importer) importWorkbooks(ctx context.Context) (int, error) {
 	workbooksDir := filepath.Join(i.dataDir, "workbooks")
 	files, err := filepath.Glob(filepath.Join(workbooksDir, "*.yml"))
 	if err != nil {
@@ -209,43 +265,45 @@ func (i *Importer) importWorkbooks(ctx context.Context, qtx *db.Queries) (int, e
 
 	count := 0
 	for _, file := range files {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return 0, fmt.Errorf("failed to read %s: %w", file, err)
-		}
-
-		var w WorkbookYAML
-		if err := yaml.Unmarshal(data, &w); err != nil {
-			return 0, fmt.Errorf("failed to parse %s: %w", file, err)
-		}
-
-		// workbooks テーブルに挿入
-		if err := qtx.ImportWorkbook(ctx, db.ImportWorkbookParams{
-			ID:          w.ID,
-			Title:       w.Title,
-			Description: sql.NullString{String: w.Description, Valid: w.Description != ""},
-		}); err != nil {
-			return 0, fmt.Errorf("failed to insert workbook %d: %w", w.ID, err)
-		}
-
-		// 問題を紐付け
-		for idx, questionID := range w.Questions {
-			if err := qtx.ImportWorkbookQuestion(ctx, db.ImportWorkbookQuestionParams{
-				WorkbookID: w.ID,
-				QuestionID: questionID,
-				OrderIndex: int32(idx),
-			}); err != nil {
-				return 0, fmt.Errorf("failed to link question for %d: %w", w.ID, err)
+		err := i.runInTxWithRetry(ctx, func(qtx *db.Queries, tx *sql.Tx) error {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", file, err)
 			}
-		}
 
+			var w WorkbookYAML
+			if err := yaml.Unmarshal(data, &w); err != nil {
+				return fmt.Errorf("failed to parse %s: %w", file, err)
+			}
+
+			if err := qtx.ImportWorkbook(ctx, db.ImportWorkbookParams{
+				ID:          w.ID,
+				Title:       w.Title,
+				Description: sql.NullString{String: w.Description, Valid: w.Description != ""},
+			}); err != nil {
+				return fmt.Errorf("failed to insert workbook %d: %w", w.ID, err)
+			}
+
+			for idx, questionID := range w.Questions {
+				if err := qtx.ImportWorkbookQuestion(ctx, db.ImportWorkbookQuestionParams{
+					WorkbookID: w.ID,
+					QuestionID: questionID,
+					OrderIndex: int32(idx),
+				}); err != nil {
+					return fmt.Errorf("failed to link question for %d: %w", w.ID, err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, err
+		}
 		count++
 	}
-
 	return count, nil
 }
 
-func (i *Importer) importCategories(ctx context.Context, qtx *db.Queries) (int, error) {
+func (i *Importer) importCategories(ctx context.Context) (int, error) {
 	categoriesDir := filepath.Join(i.dataDir, "categories")
 	files, err := filepath.Glob(filepath.Join(categoriesDir, "*.yml"))
 	if err != nil {
@@ -254,38 +312,40 @@ func (i *Importer) importCategories(ctx context.Context, qtx *db.Queries) (int, 
 
 	count := 0
 	for _, file := range files {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return 0, fmt.Errorf("failed to read %s: %w", file, err)
-		}
-
-		var c CategoryYAML
-		if err := yaml.Unmarshal(data, &c); err != nil {
-			return 0, fmt.Errorf("failed to parse %s: %w", file, err)
-		}
-
-		// categories テーブルに挿入
-		if err := qtx.ImportCategory(ctx, db.ImportCategoryParams{
-			ID:          c.ID,
-			Title:       c.Title,
-			Description: sql.NullString{String: c.Description, Valid: c.Description != ""},
-		}); err != nil {
-			return 0, fmt.Errorf("failed to insert category %d: %w", c.ID, err)
-		}
-
-		// 問題集にカテゴリIDを設定
-		for _, workbookID := range c.Workbooks {
-			if err := qtx.SetWorkbookCategory(ctx, db.SetWorkbookCategoryParams{
-				CategoryID: sql.NullInt64{Int64: c.ID, Valid: true},
-				ID:         workbookID,
-			}); err != nil {
-				return 0, fmt.Errorf("failed to set category for workbook %d: %w", workbookID, err)
+		err := i.runInTxWithRetry(ctx, func(qtx *db.Queries, tx *sql.Tx) error {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", file, err)
 			}
-		}
 
+			var c CategoryYAML
+			if err := yaml.Unmarshal(data, &c); err != nil {
+				return fmt.Errorf("failed to parse %s: %w", file, err)
+			}
+
+			if err := qtx.ImportCategory(ctx, db.ImportCategoryParams{
+				ID:          c.ID,
+				Title:       c.Title,
+				Description: sql.NullString{String: c.Description, Valid: c.Description != ""},
+			}); err != nil {
+				return fmt.Errorf("failed to insert category %d: %w", c.ID, err)
+			}
+
+			for _, workbookID := range c.Workbooks {
+				if err := qtx.SetWorkbookCategory(ctx, db.SetWorkbookCategoryParams{
+					CategoryID: sql.NullInt64{Int64: c.ID, Valid: true},
+					ID:         workbookID,
+				}); err != nil {
+					return fmt.Errorf("failed to set category for workbook %d: %w", workbookID, err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, err
+		}
 		count++
 	}
-
 	return count, nil
 }
 

--- a/app/sql/queries/importer.sql
+++ b/app/sql/queries/importer.sql
@@ -23,30 +23,32 @@ DELETE FROM questions;
 DELETE FROM images;
 
 -- name: ImportImage :exec
-INSERT INTO images (id, path) VALUES ($1, $2);
+INSERT INTO images (id, path) VALUES ($1, $2) ON CONFLICT DO NOTHING;
 
 -- name: ImportQuestion :exec
-INSERT INTO questions (id, type) VALUES ($1, $2);
+INSERT INTO questions (id, type) VALUES ($1, $2) ON CONFLICT DO NOTHING;
 
 -- name: ImportSingleChoice :one
 INSERT INTO questions_single_choice (question_id, text, explanation)
-VALUES ($1, $2, $3) RETURNING id;
+VALUES ($1, $2, $3)
+ON CONFLICT (question_id) DO UPDATE SET text = EXCLUDED.text, explanation = EXCLUDED.explanation
+RETURNING id;
 
 -- name: ImportChoice :exec
 INSERT INTO questions_single_choice_choices (single_choice_id, choice_index, text, is_correct)
-VALUES ($1, $2, $3, $4);
+VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING;
 
 -- name: ImportQuestionImage :exec
-INSERT INTO question_images (question_id, image_id, order_index) VALUES ($1, $2, $3);
+INSERT INTO question_images (question_id, image_id, order_index) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
 
 -- name: ImportWorkbook :exec
-INSERT INTO workbooks (id, title, description) VALUES ($1, $2, $3);
+INSERT INTO workbooks (id, title, description) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
 
 -- name: ImportWorkbookQuestion :exec
-INSERT INTO workbook_questions (workbook_id, question_id, order_index) VALUES ($1, $2, $3);
+INSERT INTO workbook_questions (workbook_id, question_id, order_index) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
 
 -- name: ImportCategory :exec
-INSERT INTO categories (id, title, description) VALUES ($1, $2, $3);
+INSERT INTO categories (id, title, description) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
 
 -- name: SetWorkbookCategory :exec
 UPDATE workbooks SET category_id = $1 WHERE id = $2;


### PR DESCRIPTION
## Summary

- トランザクションをフェーズごとに分割（問題は1問ずつ独立したトランザクション）
- 接続リセット時のリトライロジックを追加（最大5回、2秒間隔）
- `INSERT` を `ON CONFLICT DO NOTHING` に変更してリトライを冪等化
- Neon 向けに接続プールのライフタイムを短く設定（MaxLifetime 30s / MaxIdleTime 10s）
- `--workbooks-only` フラグを追加（問題はスキップして workbooks/categories のみ再実行可能）

## Background

Neon のコネクションプロキシが長時間の接続を TCP レベルでリセットする。
1つの大きなトランザクションで全データを処理していたため途中で失敗していた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)