### PR TITLE
fix(ci): Lambda デプロイ時の環境変数漏洩を防止

### DIFF
--- a/.github/workflows/deploy-admin-api-dev.yml
+++ b/.github/workflows/deploy-admin-api-dev.yml
@@ -54,10 +54,13 @@ jobs:
         env:
           FUNCTION_NAME: rikako-admin-api-development
         run: |
-          aws lambda update-function-code \
+          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
+          VERSION=$(aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/.github/workflows/deploy-admin-api-prod.yml
+++ b/.github/workflows/deploy-admin-api-prod.yml
@@ -51,10 +51,13 @@ jobs:
         env:
           FUNCTION_NAME: rikako-admin-api-production
         run: |
-          aws lambda update-function-code \
+          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
+          VERSION=$(aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/.github/workflows/deploy-api-dev.yml
+++ b/.github/workflows/deploy-api-dev.yml
@@ -54,10 +54,13 @@ jobs:
         env:
           FUNCTION_NAME: rikako-api-development
         run: |
-          aws lambda update-function-code \
+          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
+          VERSION=$(aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/.github/workflows/deploy-api-prod.yml
+++ b/.github/workflows/deploy-api-prod.yml
@@ -51,10 +51,13 @@ jobs:
         env:
           FUNCTION_NAME: rikako-api-production
         run: |
-          aws lambda update-function-code \
+          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
+          VERSION=$(aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \


### PR DESCRIPTION
## 概要

\`aws lambda update-function-code\` のデフォルト出力には Lambda 関数の **Environment.Variables（OPENAI_API_KEY や SLACK_WEBHOOK_URL を含む）** がそのまま含まれており、Public リポジトリの Actions ログに露出している状態だった。\`--output text --query 'Version'\` で Version 番号のみ抽出するように修正。

## 影響範囲

dev / prod / 公開API / 管理API の 4 ワークフロー全て：

- \`deploy-api-prod.yml\`
- \`deploy-admin-api-prod.yml\`
- \`deploy-api-dev.yml\`
- \`deploy-admin-api-dev.yml\`

## 別途必要な対応（このPR外）

⚠️ **既に公開ログに残ってしまった key のローテーション:**
- [ ] prod の OpenAI API key を revoke → 新規発行 → SSM 更新
- [ ] dev の OpenAI API key を revoke → 新規発行 → SSM 更新
- [ ] prod の Slack Webhook を revoke → 新規発行 → SSM 更新
- [ ] dev の Slack Webhook を revoke → 新規発行 → SSM 更新
- [ ] 過去の deploy run のログ削除（dev のみ複数件あり）

## Test plan
- [ ] このPRをマージ後、dev に再デプロイし新しい run のログに環境変数が出ていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)