### PR TITLE
feat: Lambda 環境変数の SSM Parameter Store 自動解決 (#199)

### DIFF
--- a/app/cmd/admin/main.go
+++ b/app/cmd/admin/main.go
@@ -17,10 +17,16 @@ import (
 	"github.com/takoikatakotako/rikako/internal/admin"
 	"github.com/takoikatakotako/rikako/internal/adminapi"
 	"github.com/takoikatakotako/rikako/internal/logging"
+	"github.com/takoikatakotako/rikako/internal/secrets"
 )
 
 func main() {
 	logger := logging.NewLogger()
+
+	if err := secrets.Resolve(context.Background()); err != nil {
+		logger.Error("failed to resolve SSM secrets", "error", err)
+		os.Exit(1)
+	}
 
 	// DB接続
 	dsn := os.Getenv("DATABASE_URL")

--- a/app/cmd/importer/main.go
+++ b/app/cmd/importer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"log"
@@ -9,6 +10,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/takoikatakotako/rikako/internal/importer"
+	"github.com/takoikatakotako/rikako/internal/secrets"
 )
 
 func main() {
@@ -16,6 +18,10 @@ func main() {
 	checkOnly := flag.Bool("check-only", false, "データベースの問題数を確認するのみ")
 	workbooksOnly := flag.Bool("workbooks-only", false, "workbooks/categoriesのみインポート（問題は既存のものを使用）")
 	flag.Parse()
+
+	if err := secrets.Resolve(context.Background()); err != nil {
+		log.Fatalf("Failed to resolve SSM secrets: %v", err)
+	}
 
 	// DB接続
 	dsn := os.Getenv("DATABASE_URL")

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"log/slog"
@@ -17,10 +18,16 @@ import (
 	"github.com/takoikatakotako/rikako/internal/identity"
 	"github.com/takoikatakotako/rikako/internal/logging"
 	"github.com/takoikatakotako/rikako/internal/openai"
+	"github.com/takoikatakotako/rikako/internal/secrets"
 )
 
 func main() {
 	logger := logging.NewLogger()
+
+	if err := secrets.Resolve(context.Background()); err != nil {
+		logger.Error("failed to resolve SSM secrets", "error", err)
+		os.Exit(1)
+	}
 
 	// DB接続
 	dsn := os.Getenv("DATABASE_URL")

--- a/app/internal/secrets/ssmenv.go
+++ b/app/internal/secrets/ssmenv.go
@@ -1,0 +1,144 @@
+// Package secrets は環境変数中の SSM Parameter Store 参照を起動時に解決する。
+//
+// Lambda 環境変数に値そのものを書くと aws lambda update-function-code の
+// レスポンス JSON 経由でログに露出するため、値の代わりに "ssm:/path" 形式の
+// 参照を入れておき、起動時に実値を SSM から取得して os.Setenv で展開する。
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+const ssmPrefix = "ssm:"
+
+const batchSize = 10
+
+// ParameterFetcher は ssm.Client.GetParameters のテスト用抽象。
+type ParameterFetcher interface {
+	GetParameters(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error)
+}
+
+// Resolve は os.Environ() を走査し、値が "ssm:" プレフィックス付きの環境変数を
+// SSM Parameter Store から取得した実値で上書きする。
+func Resolve(ctx context.Context) error {
+	refs, err := collectSSMRefs(os.Environ())
+	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("aws config load: %w", err)
+	}
+	return ResolveWith(ctx, ssm.NewFromConfig(cfg))
+}
+
+// ResolveWith は Resolve と同じ処理を、注入された fetcher を用いて行う。
+// 主にテスト用。
+func ResolveWith(ctx context.Context, fetcher ParameterFetcher) error {
+	refs, err := collectSSMRefs(os.Environ())
+	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+
+	pathToValue, err := fetchAll(ctx, fetcher, uniquePaths(refs))
+	if err != nil {
+		return err
+	}
+
+	for envKey, path := range refs {
+		v, ok := pathToValue[path]
+		if !ok {
+			return fmt.Errorf("ssm: resolved value missing for %s (%s)", envKey, path)
+		}
+		if err := os.Setenv(envKey, v); err != nil {
+			return fmt.Errorf("ssm: setenv %s: %w", envKey, err)
+		}
+	}
+	return nil
+}
+
+// collectSSMRefs は os.Environ() 形式の "KEY=VALUE" スライスを走査し、
+// 値が ssm: プレフィックス付きの環境変数を envKey -> ssmPath で返す。
+func collectSSMRefs(env []string) (map[string]string, error) {
+	refs := map[string]string{}
+	for _, kv := range env {
+		i := strings.IndexByte(kv, '=')
+		if i < 0 {
+			continue
+		}
+		key, val := kv[:i], kv[i+1:]
+		if !strings.HasPrefix(val, ssmPrefix) {
+			continue
+		}
+		path := strings.TrimPrefix(val, ssmPrefix)
+		if !strings.HasPrefix(path, "/") {
+			return nil, fmt.Errorf("ssm: invalid reference for %s: path must start with '/' (got %q)", key, path)
+		}
+		refs[key] = path
+	}
+	return refs, nil
+}
+
+func uniquePaths(refs map[string]string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(refs))
+	for _, p := range refs {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+func chunk(items []string, size int) [][]string {
+	if size <= 0 {
+		return nil
+	}
+	out := make([][]string, 0, (len(items)+size-1)/size)
+	for i := 0; i < len(items); i += size {
+		end := i + size
+		if end > len(items) {
+			end = len(items)
+		}
+		out = append(out, items[i:end])
+	}
+	return out
+}
+
+func fetchAll(ctx context.Context, fetcher ParameterFetcher, paths []string) (map[string]string, error) {
+	pathToValue := make(map[string]string, len(paths))
+	for _, batch := range chunk(paths, batchSize) {
+		out, err := fetcher.GetParameters(ctx, &ssm.GetParametersInput{
+			Names:          batch,
+			WithDecryption: aws.Bool(true),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("ssm: GetParameters: %w", err)
+		}
+		if len(out.InvalidParameters) > 0 {
+			return nil, fmt.Errorf("ssm: invalid parameters: %v", out.InvalidParameters)
+		}
+		for _, p := range out.Parameters {
+			if p.Name != nil && p.Value != nil {
+				pathToValue[*p.Name] = *p.Value
+			}
+		}
+	}
+	return pathToValue, nil
+}

--- a/app/internal/secrets/ssmenv_test.go
+++ b/app/internal/secrets/ssmenv_test.go
@@ -1,0 +1,206 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+type fakeFetcher struct {
+	params  map[string]string
+	invalid []string
+	err     error
+	calls   int
+}
+
+func (f *fakeFetcher) GetParameters(ctx context.Context, in *ssm.GetParametersInput, _ ...func(*ssm.Options)) (*ssm.GetParametersOutput, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := &ssm.GetParametersOutput{}
+	for _, name := range in.Names {
+		if v, ok := f.params[name]; ok {
+			n := name
+			val := v
+			out.Parameters = append(out.Parameters, ssmtypes.Parameter{Name: &n, Value: &val})
+			continue
+		}
+		out.InvalidParameters = append(out.InvalidParameters, name)
+	}
+	if len(f.invalid) > 0 {
+		out.InvalidParameters = append(out.InvalidParameters, f.invalid...)
+	}
+	return out, nil
+}
+
+func TestCollectSSMRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "no ssm references",
+			env:  []string{"FOO=bar", "BAZ=qux"},
+			want: map[string]string{},
+		},
+		{
+			name: "single reference",
+			env:  []string{"FOO=ssm:/a/b/c"},
+			want: map[string]string{"FOO": "/a/b/c"},
+		},
+		{
+			name: "mixed references",
+			env:  []string{"FOO=ssm:/a/b", "BAR=plain", "BAZ=ssm:/c/d"},
+			want: map[string]string{"FOO": "/a/b", "BAZ": "/c/d"},
+		},
+		{
+			name:    "missing leading slash",
+			env:     []string{"FOO=ssm:bad"},
+			wantErr: true,
+		},
+		{
+			name: "ignores entries without '='",
+			env:  []string{"FOO=ssm:/x", "BROKEN"},
+			want: map[string]string{"FOO": "/x"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := collectSSMRefs(tt.env)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChunk(t *testing.T) {
+	got := chunk([]string{"a", "b", "c", "d", "e"}, 2)
+	want := [][]string{{"a", "b"}, {"c", "d"}, {"e"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if chunk([]string{"a"}, 0) != nil {
+		t.Fatalf("expected nil for non-positive size")
+	}
+}
+
+func TestUniquePaths(t *testing.T) {
+	got := uniquePaths(map[string]string{"A": "/x", "B": "/x", "C": "/y"})
+	sort.Strings(got)
+	want := []string{"/x", "/y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveWith_NoRefs(t *testing.T) {
+	t.Setenv("FOO", "plain")
+	f := &fakeFetcher{}
+	if err := ResolveWith(context.Background(), f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.calls != 0 {
+		t.Fatalf("fetcher should not be called when no ssm refs, got %d", f.calls)
+	}
+}
+
+func TestResolveWith_Single(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "ssm:/rikako/dev/openai")
+	f := &fakeFetcher{params: map[string]string{"/rikako/dev/openai": "sk-real-value"}}
+	if err := ResolveWith(context.Background(), f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("OPENAI_API_KEY"); got != "sk-real-value" {
+		t.Fatalf("got %q, want %q", got, "sk-real-value")
+	}
+	if f.calls != 1 {
+		t.Fatalf("expected 1 fetch call, got %d", f.calls)
+	}
+}
+
+func TestResolveWith_DuplicatePath(t *testing.T) {
+	t.Setenv("A", "ssm:/shared")
+	t.Setenv("B", "ssm:/shared")
+	f := &fakeFetcher{params: map[string]string{"/shared": "v"}}
+	if err := ResolveWith(context.Background(), f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if os.Getenv("A") != "v" || os.Getenv("B") != "v" {
+		t.Fatalf("A=%q B=%q", os.Getenv("A"), os.Getenv("B"))
+	}
+	if f.calls != 1 {
+		t.Fatalf("expected 1 fetch call (deduped), got %d", f.calls)
+	}
+}
+
+func TestResolveWith_BatchOverTen(t *testing.T) {
+	want := map[string]string{}
+	for i := 0; i < 11; i++ {
+		envKey := "K" + string(rune('A'+i))
+		path := "/p/" + string(rune('a'+i))
+		t.Setenv(envKey, "ssm:"+path)
+		want[path] = "val-" + string(rune('a'+i))
+	}
+	f := &fakeFetcher{params: want}
+	if err := ResolveWith(context.Background(), f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.calls != 2 {
+		t.Fatalf("expected 2 batch calls for 11 items, got %d", f.calls)
+	}
+}
+
+func TestResolveWith_InvalidParameter(t *testing.T) {
+	t.Setenv("FOO", "ssm:/missing")
+	f := &fakeFetcher{params: map[string]string{}}
+	err := ResolveWith(context.Background(), f)
+	if err == nil || !strings.Contains(err.Error(), "invalid parameters") {
+		t.Fatalf("expected invalid parameters error, got %v", err)
+	}
+}
+
+func TestResolveWith_FetchError(t *testing.T) {
+	t.Setenv("FOO", "ssm:/x")
+	sentinel := errors.New("boom")
+	f := &fakeFetcher{err: sentinel}
+	err := ResolveWith(context.Background(), f)
+	if err == nil || !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
+	}
+}
+
+func TestResolveWith_InvalidPrefix(t *testing.T) {
+	t.Setenv("FOO", "ssm:no-leading-slash")
+	f := &fakeFetcher{}
+	err := ResolveWith(context.Background(), f)
+	if err == nil {
+		t.Fatalf("expected error for invalid prefix, got nil")
+	}
+	if f.calls != 0 {
+		t.Fatalf("fetcher should not be called on parse error, got %d", f.calls)
+	}
+}
+
+// suppress unused import warnings if aws helper isn't used elsewhere in tests
+var _ = aws.Bool

--- a/terraform/environments/dev/lambda/slack_notifier/index.py
+++ b/terraform/environments/dev/lambda/slack_notifier/index.py
@@ -3,7 +3,25 @@ import json
 import os
 import urllib.request
 
-WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]
+import boto3
+
+
+def _resolve_ssm(env_name: str) -> str:
+    """環境変数の値が "ssm:" プレフィックス付きなら SSM から実値を取得する。
+
+    Lambda 環境変数に値を直接書くと update-function-code のレスポンス JSON 経由で
+    ログに露出するため、参照のみを env に置いて起動時に SSM から取得する。
+    """
+    val = os.environ[env_name]
+    if val.startswith("ssm:"):
+        path = val[len("ssm:"):]
+        client = boto3.client("ssm")
+        resp = client.get_parameter(Name=path, WithDecryption=True)
+        return resp["Parameter"]["Value"]
+    return val
+
+
+WEBHOOK_URL = _resolve_ssm("SLACK_WEBHOOK_URL")
 
 
 def handler(event, _context):

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,27 +1,37 @@
 # =============================================================================
-# OpenAI APIキー
+# Lambda 環境変数の SSM 参照
 # =============================================================================
-# 事前準備: OpenAI APIキーを SSM Parameter Store に SecureString で保存
+# シークレットは Lambda 環境変数に値を直接埋め込まず、SSM Parameter Store の
+# パスを "ssm:..." 形式で参照する。アプリ側 (internal/secrets.Resolve または
+# slack_notifier の _resolve_ssm) が起動時に実値を取得する。
+#
+# 事前準備（手動）:
 #   aws ssm put-parameter --name /rikako/development/openai-api-key \
 #     --value 'sk-...' --type SecureString
-# =============================================================================
-
-data "aws_ssm_parameter" "openai_api_key" {
-  name            = "/${local.project}/${local.environment}/openai-api-key"
-  with_decryption = true
-}
-
-# =============================================================================
-# Slack Webhook URL（お問い合わせ通知用）
-# =============================================================================
-# 事前準備: Slack Webhook URLを SSM Parameter Store に SecureString で保存
 #   aws ssm put-parameter --name /rikako/development/slack-contact-webhook-url \
 #     --value 'https://hooks.slack.com/services/...' --type SecureString
+#
+# DATABASE_URL は neon_project の connection_uri から Terraform が SecureString として登録する。
 # =============================================================================
 
-data "aws_ssm_parameter" "slack_contact_webhook_url" {
-  name            = "/${local.project}/${local.environment}/slack-contact-webhook-url"
-  with_decryption = true
+resource "aws_ssm_parameter" "database_url" {
+  name        = "/${local.project}/${local.environment}/database-url"
+  type        = "SecureString"
+  value       = neon_project.default.connection_uri
+  description = "Neon DB connection URI (managed by Terraform)"
+}
+
+locals {
+  api_ssm_param_names = [
+    "/${local.project}/${local.environment}/openai-api-key",
+    "/${local.project}/${local.environment}/slack-contact-webhook-url",
+    aws_ssm_parameter.database_url.name,
+  ]
+  admin_api_ssm_param_names = [
+    aws_ssm_parameter.database_url.name,
+  ]
+
+  ssm_param_arn_prefix = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 # Lambda Function (Public API)
@@ -37,7 +47,7 @@ module "lambda" {
   cognito_identity_pool_arn = module.cognito_identity.identity_pool_arn
 
   environment_variables = {
-    DATABASE_URL                     = neon_project.default.connection_uri
+    DATABASE_URL                     = "ssm:${aws_ssm_parameter.database_url.name}"
     PORT                             = "8080"
     ENVIRONMENT                      = local.environment
     IMAGE_BASE_URL                   = "https://${module.image_cloudfront.domain_name}"
@@ -49,9 +59,11 @@ module "lambda" {
     COGNITO_IDENTITY_POOL_ID         = module.cognito_identity.identity_pool_id
     MINIMUM_VERSION                  = "1.0.0"
     LATEST_VERSION                   = "1.0.0"
-    OPENAI_API_KEY                   = data.aws_ssm_parameter.openai_api_key.value
-    SLACK_WEBHOOK_URL                = data.aws_ssm_parameter.slack_contact_webhook_url.value
+    OPENAI_API_KEY                   = "ssm:/${local.project}/${local.environment}/openai-api-key"
+    SLACK_WEBHOOK_URL                = "ssm:/${local.project}/${local.environment}/slack-contact-webhook-url"
   }
+
+  ssm_parameter_arns = [for name in local.api_ssm_param_names : "${local.ssm_param_arn_prefix}${name}"]
 
   create_function_url = false
   log_retention_days  = 7
@@ -94,7 +106,7 @@ module "lambda_admin" {
   memory_size            = 512
 
   environment_variables = {
-    DATABASE_URL                     = neon_project.default.connection_uri
+    DATABASE_URL                     = "ssm:${aws_ssm_parameter.database_url.name}"
     PORT                             = "8080"
     ENVIRONMENT                      = local.environment
     IMAGE_BASE_URL                   = "https://${module.image_cloudfront.domain_name}"
@@ -105,6 +117,8 @@ module "lambda_admin" {
     AWS_LWA_READINESS_CHECK_PORT     = "8080"
     AWS_LWA_READINESS_CHECK_PATH     = "/health"
   }
+
+  ssm_parameter_arns = [for name in local.admin_api_ssm_param_names : "${local.ssm_param_arn_prefix}${name}"]
 
   log_retention_days = 7
 

--- a/terraform/environments/dev/monitoring.tf
+++ b/terraform/environments/dev/monitoring.tf
@@ -1,14 +1,16 @@
 # =============================================================================
 # Slack 通知
 # =============================================================================
-# 事前準備: Slack Incoming Webhook URL を SSM Parameter Store に SecureString で保存
+# Slack Webhook URL は Lambda env に "ssm:..." 形式で参照を入れ、起動時に
+# slack_notifier の _resolve_ssm が SSM から実値を取得する。
+#
+# 事前準備（手動）:
 #   aws ssm put-parameter --name /rikako/development/slack-alert-webhook-url \
 #     --value 'https://hooks.slack.com/services/...' --type SecureString
 # =============================================================================
 
-data "aws_ssm_parameter" "slack_alert_webhook_url" {
-  name            = "/${local.project}/${local.environment}/slack-alert-webhook-url"
-  with_decryption = true
+locals {
+  slack_alert_webhook_url_param_name = "/${local.project}/${local.environment}/slack-alert-webhook-url"
 }
 
 resource "aws_sns_topic" "alerts" {
@@ -46,6 +48,20 @@ resource "aws_iam_role_policy_attachment" "slack_notifier_logs" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+resource "aws_iam_role_policy" "slack_notifier_ssm" {
+  name = "ssm-parameter-read"
+  role = aws_iam_role.slack_notifier.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameter"]
+      Resource = "${local.ssm_param_arn_prefix}${local.slack_alert_webhook_url_param_name}"
+    }]
+  })
+}
+
 resource "aws_cloudwatch_log_group" "slack_notifier" {
   name              = "/aws/lambda/${local.project}-slack-notifier-${local.environment}"
   retention_in_days = 14
@@ -63,7 +79,7 @@ resource "aws_lambda_function" "slack_notifier" {
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = data.aws_ssm_parameter.slack_alert_webhook_url.value
+      SLACK_WEBHOOK_URL = "ssm:${local.slack_alert_webhook_url_param_name}"
     }
   }
 

--- a/terraform/environments/prod/lambda/slack_notifier/index.py
+++ b/terraform/environments/prod/lambda/slack_notifier/index.py
@@ -3,7 +3,25 @@ import json
 import os
 import urllib.request
 
-WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]
+import boto3
+
+
+def _resolve_ssm(env_name: str) -> str:
+    """環境変数の値が "ssm:" プレフィックス付きなら SSM から実値を取得する。
+
+    Lambda 環境変数に値を直接書くと update-function-code のレスポンス JSON 経由で
+    ログに露出するため、参照のみを env に置いて起動時に SSM から取得する。
+    """
+    val = os.environ[env_name]
+    if val.startswith("ssm:"):
+        path = val[len("ssm:"):]
+        client = boto3.client("ssm")
+        resp = client.get_parameter(Name=path, WithDecryption=True)
+        return resp["Parameter"]["Value"]
+    return val
+
+
+WEBHOOK_URL = _resolve_ssm("SLACK_WEBHOOK_URL")
 
 
 def handler(event, _context):

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,27 +1,37 @@
 # =============================================================================
-# OpenAI APIキー
+# Lambda 環境変数の SSM 参照
 # =============================================================================
-# 事前準備: OpenAI APIキーを SSM Parameter Store に SecureString で保存
+# シークレットは Lambda 環境変数に値を直接埋め込まず、SSM Parameter Store の
+# パスを "ssm:..." 形式で参照する。アプリ側 (internal/secrets.Resolve または
+# slack_notifier の _resolve_ssm) が起動時に実値を取得する。
+#
+# 事前準備（手動）:
 #   aws ssm put-parameter --name /rikako/production/openai-api-key \
 #     --value 'sk-...' --type SecureString
-# =============================================================================
-
-data "aws_ssm_parameter" "openai_api_key" {
-  name            = "/${local.project}/${local.environment}/openai-api-key"
-  with_decryption = true
-}
-
-# =============================================================================
-# Slack Webhook URL（お問い合わせ通知用）
-# =============================================================================
-# 事前準備: Slack Webhook URLを SSM Parameter Store に SecureString で保存
 #   aws ssm put-parameter --name /rikako/production/slack-contact-webhook-url \
 #     --value 'https://hooks.slack.com/services/...' --type SecureString
+#
+# DATABASE_URL は neon_project の connection_uri から Terraform が SecureString として登録する。
 # =============================================================================
 
-data "aws_ssm_parameter" "slack_contact_webhook_url" {
-  name            = "/${local.project}/${local.environment}/slack-contact-webhook-url"
-  with_decryption = true
+resource "aws_ssm_parameter" "database_url" {
+  name        = "/${local.project}/${local.environment}/database-url"
+  type        = "SecureString"
+  value       = neon_project.default.connection_uri
+  description = "Neon DB connection URI (managed by Terraform)"
+}
+
+locals {
+  api_ssm_param_names = [
+    "/${local.project}/${local.environment}/openai-api-key",
+    "/${local.project}/${local.environment}/slack-contact-webhook-url",
+    aws_ssm_parameter.database_url.name,
+  ]
+  admin_api_ssm_param_names = [
+    aws_ssm_parameter.database_url.name,
+  ]
+
+  ssm_param_arn_prefix = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 # Lambda Function (Public API)
@@ -37,7 +47,7 @@ module "lambda" {
   cognito_identity_pool_arn = module.cognito_identity.identity_pool_arn
 
   environment_variables = {
-    DATABASE_URL                     = neon_project.default.connection_uri
+    DATABASE_URL                     = "ssm:${aws_ssm_parameter.database_url.name}"
     PORT                             = "8080"
     ENVIRONMENT                      = local.environment
     IMAGE_BASE_URL                   = "https://${module.image_cloudfront.domain_name}"
@@ -49,9 +59,11 @@ module "lambda" {
     COGNITO_IDENTITY_POOL_ID         = module.cognito_identity.identity_pool_id
     MINIMUM_VERSION                  = "1.0.0"
     LATEST_VERSION                   = "1.0.0"
-    OPENAI_API_KEY                   = data.aws_ssm_parameter.openai_api_key.value
-    SLACK_WEBHOOK_URL                = data.aws_ssm_parameter.slack_contact_webhook_url.value
+    OPENAI_API_KEY                   = "ssm:/${local.project}/${local.environment}/openai-api-key"
+    SLACK_WEBHOOK_URL                = "ssm:/${local.project}/${local.environment}/slack-contact-webhook-url"
   }
+
+  ssm_parameter_arns = [for name in local.api_ssm_param_names : "${local.ssm_param_arn_prefix}${name}"]
 
   create_function_url = false
   log_retention_days  = 30
@@ -94,7 +106,7 @@ module "lambda_admin" {
   memory_size            = 512
 
   environment_variables = {
-    DATABASE_URL                     = neon_project.default.connection_uri
+    DATABASE_URL                     = "ssm:${aws_ssm_parameter.database_url.name}"
     PORT                             = "8080"
     ENVIRONMENT                      = local.environment
     IMAGE_BASE_URL                   = "https://${module.image_cloudfront.domain_name}"
@@ -105,6 +117,8 @@ module "lambda_admin" {
     AWS_LWA_READINESS_CHECK_PORT     = "8080"
     AWS_LWA_READINESS_CHECK_PATH     = "/health"
   }
+
+  ssm_parameter_arns = [for name in local.admin_api_ssm_param_names : "${local.ssm_param_arn_prefix}${name}"]
 
   log_retention_days = 30
 

--- a/terraform/environments/prod/monitoring.tf
+++ b/terraform/environments/prod/monitoring.tf
@@ -1,14 +1,16 @@
 # =============================================================================
 # Slack 通知
 # =============================================================================
-# 事前準備: Slack Incoming Webhook URL を SSM Parameter Store に SecureString で保存
+# Slack Webhook URL は Lambda env に "ssm:..." 形式で参照を入れ、起動時に
+# slack_notifier の _resolve_ssm が SSM から実値を取得する。
+#
+# 事前準備（手動）:
 #   aws ssm put-parameter --name /rikako/production/slack-alert-webhook-url \
 #     --value 'https://hooks.slack.com/services/...' --type SecureString
 # =============================================================================
 
-data "aws_ssm_parameter" "slack_alert_webhook_url" {
-  name            = "/${local.project}/${local.environment}/slack-alert-webhook-url"
-  with_decryption = true
+locals {
+  slack_alert_webhook_url_param_name = "/${local.project}/${local.environment}/slack-alert-webhook-url"
 }
 
 resource "aws_sns_topic" "alerts" {
@@ -46,6 +48,20 @@ resource "aws_iam_role_policy_attachment" "slack_notifier_logs" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+resource "aws_iam_role_policy" "slack_notifier_ssm" {
+  name = "ssm-parameter-read"
+  role = aws_iam_role.slack_notifier.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameter"]
+      Resource = "${local.ssm_param_arn_prefix}${local.slack_alert_webhook_url_param_name}"
+    }]
+  })
+}
+
 resource "aws_cloudwatch_log_group" "slack_notifier" {
   name              = "/aws/lambda/${local.project}-slack-notifier-${local.environment}"
   retention_in_days = 30
@@ -63,7 +79,7 @@ resource "aws_lambda_function" "slack_notifier" {
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = data.aws_ssm_parameter.slack_alert_webhook_url.value
+      SLACK_WEBHOOK_URL = "ssm:${local.slack_alert_webhook_url_param_name}"
     }
   }
 

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -70,6 +70,24 @@ resource "aws_iam_role_policy" "lambda_cognito_identity" {
   })
 }
 
+# SSM Parameter Store read access (for app-side env resolution; internal/secrets.Resolve)
+resource "aws_iam_role_policy" "lambda_ssm" {
+  count = length(var.ssm_parameter_arns) > 0 ? 1 : 0
+  name  = "ssm-parameter-read"
+  role  = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameters", "ssm:GetParameter"]
+        Resource = var.ssm_parameter_arns
+      }
+    ]
+  })
+}
+
 # CloudWatch Log Group
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.function_name}"

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -56,6 +56,12 @@ variable "cognito_identity_pool_arn" {
   default     = ""
 }
 
+variable "ssm_parameter_arns" {
+  description = "List of SSM Parameter ARNs the Lambda is allowed to read at startup (used by internal/secrets.Resolve)"
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)


### PR DESCRIPTION
Closes #199

## Summary

`aws lambda update-function-code` のレスポンス JSON に Lambda 環境変数が含まれ、Public リポジトリの GitHub Actions ログにシークレット（OpenAI key / Slack Webhook / DB 接続 URL）が露出した問題（#198 参照）への **根本対策**。漏洩元のワークフローは #196 で塞いだが、本 PR で環境変数にシークレット生値を持たない構成へ移行する。

### 仕組み

Lambda 環境変数の値が `ssm:` プレフィックス付き（例：`ssm:/rikako/development/openai-api-key`）なら、アプリ起動時に SSM Parameter Store から実値を取得して同名 env に注入する。`update-function-code` のレスポンスにはパスしか出なくなる。

- Go 3 cmd: `app/internal/secrets.Resolve()` を `main` 冒頭で呼ぶ
- Python slack_notifier: モジュールロード時に `_resolve_ssm()` で取得
- Terraform: env を `ssm:...` リテラルに置換、`aws_ssm_parameter.database_url` を新規作成、Lambda 実行ロールに `ssm:GetParameter(s)` 権限を追加

スコープは Issue #199 の議論で「全部入れる」と確定した範囲（公開 API / 管理 API / Python slack_notifier、対象 env：OPENAI_API_KEY / SLACK_WEBHOOK_URL / DATABASE_URL × dev/prod）。

## Test plan

- [x] `go test ./internal/secrets/...` パス（8 テストケース）
- [x] `go build ./...` 全 cmd ビルド成功
- [x] `terraform fmt -check` modules/lambda / dev / prod すべて OK
- [x] `terraform validate` dev / prod 成功
- [ ] dev: terraform apply 後、`aws lambda get-function-configuration --function-name rikako-api-development --query 'Environment.Variables'` で env が `ssm:...` リテラルになっていること（シークレット実値が出ない）を確認
- [ ] dev: `curl https://api.dev.rikako.org/health` 200
- [ ] dev: お問い合わせ API → Slack 通知到達確認
- [ ] dev: CloudWatch アラームを `aws cloudwatch set-alarm-state` で発火 → Slack alert チャンネル通知到達確認（slack_notifier 経路）
- [ ] dev 安定後、prod に apply して同じ検証

## 関連 Issue / PR

- #196 (マージ済): 漏洩元の暫定対策（`--output text --query 'Version'`）
- #198: 漏洩シークレットローテーション。本 PR で「次回ローテ時に Lambda 再デプロイ不要、SSM put-parameter のみで反映」状態になる
- #199: 本 PR

## 検討した別案（不採用）

- Lambda Layer + `AWS_LAMBDA_EXEC_WRAPPER`: 個人プロジェクト規模では over-engineering
- AWS Parameters and Secrets Lambda Extension: env 自動展開は提供しない（HTTP プロキシのみ）
- Terraform で SSM 値を展開し続ける（現状）: 漏洩の原因そのもの

詳細はプランファイル参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)