### PR TITLE
fix(ci): Lambda Deploy の wait 失敗を修正し出力抑制を解除 (#197)

### DIFF
--- a/.github/workflows/deploy-admin-api-dev.yml
+++ b/.github/workflows/deploy-admin-api-dev.yml
@@ -54,13 +54,12 @@ jobs:
         env:
           FUNCTION_NAME: rikako-admin-api-development
         run: |
-          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
-          VERSION=$(aws lambda update-function-code \
+          # シークレット系の env は全て ssm:... リテラル経由（internal/secrets.Resolve が起動時に解決）
+          # のため、デフォルト JSON 出力でも実値が露出することはない。
+          aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish \
-            --output text --query 'Version')
-          echo "Published version: $VERSION"
+            --publish
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/.github/workflows/deploy-admin-api-prod.yml
+++ b/.github/workflows/deploy-admin-api-prod.yml
@@ -51,13 +51,12 @@ jobs:
         env:
           FUNCTION_NAME: rikako-admin-api-production
         run: |
-          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
-          VERSION=$(aws lambda update-function-code \
+          # シークレット系の env は全て ssm:... リテラル経由（internal/secrets.Resolve が起動時に解決）
+          # のため、デフォルト JSON 出力でも実値が露出することはない。
+          aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish \
-            --output text --query 'Version')
-          echo "Published version: $VERSION"
+            --publish
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/.github/workflows/deploy-api-dev.yml
+++ b/.github/workflows/deploy-api-dev.yml
@@ -54,13 +54,12 @@ jobs:
         env:
           FUNCTION_NAME: rikako-api-development
         run: |
-          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
-          VERSION=$(aws lambda update-function-code \
+          # シークレット系の env は全て ssm:... リテラル経由（internal/secrets.Resolve が起動時に解決）
+          # のため、デフォルト JSON 出力でも実値が露出することはない。
+          aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish \
-            --output text --query 'Version')
-          echo "Published version: $VERSION"
+            --publish
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/.github/workflows/deploy-api-prod.yml
+++ b/.github/workflows/deploy-api-prod.yml
@@ -51,13 +51,12 @@ jobs:
         env:
           FUNCTION_NAME: rikako-api-production
         run: |
-          # 注: 出力には Environment.Variables が含まれるため、Version だけ取り出してログ露出を防ぐ
-          VERSION=$(aws lambda update-function-code \
+          # シークレット系の env は全て ssm:... リテラル経由（internal/secrets.Resolve が起動時に解決）
+          # のため、デフォルト JSON 出力でも実値が露出することはない。
+          aws lambda update-function-code \
             --function-name "$FUNCTION_NAME" \
             --image-uri "${{ steps.meta.outputs.tags }}" \
-            --publish \
-            --output text --query 'Version')
-          echo "Published version: $VERSION"
+            --publish
 
           echo "Waiting for function update to complete..."
           aws lambda wait function-updated \

--- a/terraform/environments/dev/github_actions.tf
+++ b/terraform/environments/dev/github_actions.tf
@@ -121,6 +121,7 @@ data "aws_iam_policy_document" "github_actions_lambda_deploy" {
     actions = [
       "lambda:UpdateFunctionCode",
       "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration", # aws lambda wait function-updated
     ]
     resources = [
       "arn:aws:lambda:${var.region}:${data.aws_caller_identity.current.account_id}:function:${local.project}-api-${local.environment}",

--- a/terraform/environments/prod/github_actions.tf
+++ b/terraform/environments/prod/github_actions.tf
@@ -90,6 +90,7 @@ data "aws_iam_policy_document" "github_actions_lambda_deploy" {
     actions = [
       "lambda:UpdateFunctionCode",
       "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration", # aws lambda wait function-updated
     ]
     resources = [
       "arn:aws:lambda:${var.region}:${data.aws_caller_identity.current.account_id}:function:${local.project}-api-${local.environment}",


### PR DESCRIPTION
Closes #197

## 概要

GitHub Actions ロールに `lambda:GetFunctionConfiguration` が無く、`aws lambda wait function-updated` が `AccessDeniedException` で失敗していたため、Lambda Deploy 系ワークフローが CI 上で赤くなっていた（実体の `update-function-code` 自体は成功）。

## 修正内容

### IAM
- `terraform/environments/{dev,prod}/github_actions.tf` の Lambda Deploy 用ポリシーに `lambda:GetFunctionConfiguration` を追加

### ワークフロー
PR #200 で全シークレットが Lambda 環境変数から SSM 参照（`ssm:/path` 形式のリテラル）に切り替わったため、`update-function-code` の出力抑制（`--output text --query 'Version'`）を解除し、通常の JSON 出力に戻す：

- `.github/workflows/deploy-api-prod.yml`
- `.github/workflows/deploy-admin-api-prod.yml`
- `.github/workflows/deploy-api-dev.yml`
- `.github/workflows/deploy-admin-api-dev.yml`

これにより Version / LastModified / CodeSha256 などが再びログで確認できるようになる。

## 関連

- #196: 漏洩元の暫定対策（出力抑制）。本 PR でその制約を解除
- #200: シークレットを SSM 参照に切り替えた根本対策（マージ済み）
- #197: 本 PR で Close

## Test plan

- [x] `terraform fmt -check` dev/prod 両方 OK
- [x] `terraform validate` dev/prod 両方 OK
- [ ] dev terraform apply 後、`deploy-api-dev.yml` を手動 dispatch → CI 緑（wait 成功）を確認
- [ ] prod terraform apply 後、`deploy-api-prod.yml` を手動 dispatch → CI 緑を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)