### PR TITLE
fix(terraform): Neon DB パスワードを Neon API でローテ可能にする

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -131,7 +131,7 @@ Lambda が読むシークレット（`OPENAI_API_KEY` / `SLACK_WEBHOOK_URL` / `D
 | `/rikako/<env>/openai-api-key` | OpenAI API キー | 手動 `put-parameter` |
 | `/rikako/<env>/slack-contact-webhook-url` | お問い合わせ通知用 Slack Webhook | 手動 `put-parameter` |
 | `/rikako/<env>/slack-alert-webhook-url` | CloudWatch アラート用 Slack Webhook | 手動 `put-parameter` |
-| `/rikako/<env>/database-url` | Neon 接続文字列 | Terraform が `neon_project.default.connection_uri` から `aws_ssm_parameter` で SecureString として登録 |
+| `/rikako/<env>/database-url` | Neon 接続文字列 | Terraform が `neon_project.default.connection_uri` を**初期値**として SecureString 登録。`lifecycle.ignore_changes = [value]` 指定のため以後の値はローテで上書き可（[ローテ手順](#neon-db)参照） |
 | `/rikako/neon-api-key` | Neon API キー（Terraform Provider 用） | 手動 `put-parameter` |
 
 ### 初回登録
@@ -161,6 +161,50 @@ AWS_PROFILE=rikako-development-sso aws ssm put-parameter \
 ### 確認
 
 `aws lambda get-function-configuration --query 'Environment.Variables'` で **シークレット実値が出ず `ssm:/...` リテラルだけが返る**ことを確認する。実値が露出していたら漏洩リスクがあるので即対応。
+
+### Neon DB パスワードのローテーション {#neon-db}
+
+`/rikako/<env>/database-url` の Neon パスワードをローテする手順。
+
+> **重要な前提**
+> - Neon の role は DB を所有しているため、`terraform apply -replace=neon_role.default` での drop/recreate は **HTTP 422 `ROLE_OWNS_OBJECTS`** で失敗する。ローテは必ず Neon API の **`reset_password`**（role を残しパスワードのみ再生成）で行う。
+> - SSM `database-url` は `lifecycle.ignore_changes = [value]` 指定のため、`put-parameter --overwrite` した値を terraform が巻き戻さない。
+> - **環境ごとにアプリが使う role/DB が異なる**ので注意:
+>   - **dev**: role `rikako_owner` / DB `rikako`
+>   - **prod**: role `neondb_owner` / DB `neondb`（Neon デフォルト）
+> - リセット直後から旧パスワードは無効になり、warm Lambda は cold start まで DB 接続に失敗する。
+
+```bash
+# 例: dev（prod の場合は PROFILE/PROJECT/BRANCH/ROLE/DB/SSM 名を読み替え）
+export AWS_PROFILE=rikako-development-sso
+API_KEY=$(aws ssm get-parameter --name /rikako/neon-api-key --with-decryption --query Parameter.Value --output text)
+PROJECT_ID=muddy-tree-64549662
+BRANCH_ID=br-calm-rice-a1123e1l
+ROLE=rikako_owner
+DB=rikako
+HOST=$(cd terraform/environments/dev && terraform state show neon_project.default | grep 'database_host ' | sed -E 's/.*= "(.*)"/\1/')
+
+# 1. パスワードを reset（新パスワードを取得、出力しない）
+NEWPASS=$(curl -s -X POST \
+  "https://console.neon.tech/api/v2/projects/${PROJECT_ID}/branches/${BRANCH_ID}/roles/${ROLE}/reset_password" \
+  -H "Authorization: Bearer ${API_KEY}" -H "Accept: application/json" | jq -r '.role.password')
+
+# 2. SSM を上書き
+aws ssm put-parameter --name /rikako/development/database-url --type SecureString --overwrite \
+  --value "postgres://${ROLE}:${NEWPASS}@${HOST}/${DB}?sslmode=require"
+
+# 3. Lambda を cold start（warm container に旧パスが残るため）
+TS=$(date +%s)
+for fn in rikako-api-development rikako-admin-api-development; do
+  aws lambda update-function-configuration --function-name "$fn" --description "db rotation $TS" >/dev/null
+  aws lambda wait function-updated --function-name "$fn"
+done
+
+# 4. 確認（DB を叩くエンドポイントが 200 を返すこと）
+curl -s -o /dev/null -w "%{http_code}\n" https://api.dev.rikako.org/workbooks
+```
+
+prod は次のように読み替える: `AWS_PROFILE=rikako-production-sso`、`PROJECT_ID` は `cd terraform/environments/prod && terraform state show neon_project.default` の `id`、`BRANCH_ID` は同 `default_branch_id`、`ROLE=neondb_owner`、`DB=neondb`、SSM 名 `/rikako/production/database-url`、関数は `rikako-api-production` / `rikako-admin-api-production`。
 
 ---
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -11,14 +11,25 @@
 #   aws ssm put-parameter --name /rikako/development/slack-contact-webhook-url \
 #     --value 'https://hooks.slack.com/services/...' --type SecureString
 #
-# DATABASE_URL は neon_project の connection_uri から Terraform が SecureString として登録する。
+# DATABASE_URL は neon_project の connection_uri を初期値として SecureString で登録する。
+#
+# パスワードローテーション手順:
+#   Neon の role は DB を所有しており drop/recreate (terraform -replace) できない
+#   (HTTP 422 ROLE_OWNS_OBJECTS)。そのためローテは Neon API の reset_password で行い、
+#   新しい接続文字列を `aws ssm put-parameter --overwrite` で SSM に直接書き込む。
+#   terraform が値を巻き戻さないよう lifecycle.ignore_changes = [value] を指定している。
+#   詳細手順は docs を参照。
 # =============================================================================
 
 resource "aws_ssm_parameter" "database_url" {
   name        = "/${local.project}/${local.environment}/database-url"
   type        = "SecureString"
   value       = neon_project.default.connection_uri
-  description = "Neon DB connection URI (managed by Terraform)"
+  description = "Neon DB connection URI (initial value; rotated out-of-band via Neon API)"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 locals {

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -11,14 +11,26 @@
 #   aws ssm put-parameter --name /rikako/production/slack-contact-webhook-url \
 #     --value 'https://hooks.slack.com/services/...' --type SecureString
 #
-# DATABASE_URL は neon_project の connection_uri から Terraform が SecureString として登録する。
+# DATABASE_URL は neon_project の connection_uri を初期値として SecureString で登録する。
+#
+# パスワードローテーション手順:
+#   Neon の role は DB を所有しており drop/recreate (terraform -replace) できない
+#   (HTTP 422 ROLE_OWNS_OBJECTS)。そのためローテは Neon API の reset_password で行い、
+#   新しい接続文字列を `aws ssm put-parameter --overwrite` で SSM に直接書き込む。
+#   terraform が値を巻き戻さないよう lifecycle.ignore_changes = [value] を指定している。
+#   prod のアプリが使う role は neondb_owner / DB は neondb（Neon デフォルト）である点に注意。
+#   詳細手順は docs を参照。
 # =============================================================================
 
 resource "aws_ssm_parameter" "database_url" {
   name        = "/${local.project}/${local.environment}/database-url"
   type        = "SecureString"
   value       = neon_project.default.connection_uri
-  description = "Neon DB connection URI (managed by Terraform)"
+  description = "Neon DB connection URI (initial value; rotated out-of-band via Neon API)"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 locals {


### PR DESCRIPTION
## 背景

Issue #198（漏洩シークレットのローテ）の Neon DATABASE_URL ローテ対応。

当初は `terraform apply -replace=neon_role.default` でローテしようとしたが、調査の結果:

1. `neon_project.connection_uri` はプロジェクト作成時に確定し password を再読込しないため、role を replace してもローテが SSM に伝播しない。
2. そもそも Neon の role は DB を所有しているため `-replace`（drop+create）が **HTTP 422 `ROLE_OWNS_OBJECTS`** で失敗する（dev で実際に確認）。

→ terraform でのパスワードローテは不可能。

## 変更

パスワードローテは **Neon API の `reset_password`**（role を残しパスワードのみ再生成）で行い、新接続文字列を `aws ssm put-parameter --overwrite` で SSM に直接書き込む運用に変更。terraform が値を巻き戻さないよう、dev/prod の `aws_ssm_parameter.database_url` に `lifecycle { ignore_changes = [value] }` を付与した。

手順は `docs/runbook.md`（2.5 シークレット管理 → Neon DB パスワードのローテーション）に追記。

## 環境差分（注意）

アプリが使う role/DB が環境で異なることが判明:
- **dev**: `rikako_owner` / `rikako`
- **prod**: `neondb_owner` / `neondb`（Neon デフォルト role）

## 検証

- dev で本手順による実ローテを実施済み。`/workbooks`（DB 接続）が 200 を返すことを確認。
- 両環境の `terraform plan` が **description 変更のみ・value 不変**（ignore_changes が効いている）であることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)