### PR TITLE
docs: 実構成とのドリフトを修正（Neon 構造・prod ID・モジュール一覧）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,17 @@ Rikako - 問題集アプリ
 ├── migrations/             # DBマイグレーションファイル
 ├── terraform/
 │   ├── modules/
+│   │   ├── api_gateway/    # API Gateway HTTP APIモジュール
 │   │   ├── cloudfront/     # CloudFrontモジュール
+│   │   ├── cognito/        # Cognito User Poolモジュール
+│   │   ├── cognito_identity/ # Cognito Identity Poolモジュール
 │   │   ├── ecr/            # ECRモジュール
 │   │   ├── lambda/         # Lambdaモジュール
 │   │   └── s3/             # S3モジュール
 │   └── environments/
 │       ├── shared/         # ECR（全環境共有）
-│       └── dev/            # Dev環境（Lambda + Neon + Image CDN）
+│       ├── dev/            # Dev環境（Lambda + Neon + Image/Content CDN）
+│       └── prod/           # Prod環境（dev と同構成、rikako.org 配下）
 ├── openapi.yaml            # 公開API仕様
 ├── openapi-admin.yaml      # 管理API仕様
 └── .github/workflows/      # CI設定
@@ -261,7 +265,7 @@ db.SetConnMaxIdleTime(1 * time.Minute)  // アイドル接続の最大時間
   - Lambda関数名: `rikako-api-production` / `rikako-admin-api-production` / `rikako-slack-notifier-production`
   - Image CDN: https://image.rikako.org/ (S3: `rikako-images-production`)
   - Content CDN: https://content.rikako.org/ (S3: `rikako-content-production`)
-  - Neon DB: `ep-misty-unit-aoxkoz1d` (ap-southeast-1)
+  - Neon DB: `fragrant-poetry-87067174` (ap-southeast-1、エンドポイント `ep-misty-unit-aoxkoz1d`)
   - Cognito User Pool: `ap-northeast-1_d8LkqgsJU`
   - Terraform State: `s3://rikako-prod-terraform-state`
   - 自動 apply 無し、ローカルから `AWS_PROFILE=rikako-production-sso terraform apply` で反映

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -25,7 +25,8 @@
 | 画像S3 | `rikako-images-development` | `rikako-images-production` |
 | コンテンツS3 | `rikako-content-development` | `rikako-content-production` |
 | 管理画面S3 | `rikako-admin-development` | `rikako-admin-production` |
-| Neon DB | `muddy-tree-64549662` (ap-southeast-1) | `ep-misty-unit-aoxkoz1d` (ap-southeast-1) |
+| Neon プロジェクト ID | `muddy-tree-64549662` (ap-southeast-1) | `fragrant-poetry-87067174` (ap-southeast-1) |
+| Neon エンドポイント | `ep-raspy-lab-a1wo0g6n` | `ep-misty-unit-aoxkoz1d` |
 | ECR (shared) | `579039992557.dkr.ecr.ap-northeast-1.amazonaws.com/rikako-api` | 同左 |
 | CloudWatch Dashboard | `rikako-dev` | `rikako-prod` |
 | AWSアカウント | 197865631794 | 211125415945 |
@@ -399,22 +400,26 @@ aws logs filter-log-events \
 
 ### Neon CU（コンピューティングユニット）変更
 
-現在: 0.25〜2 CU（auto-scaling）
+現在: dev は 0.25〜2 CU、prod は 0.25〜4 CU（auto-scaling、auto-suspend 無効）。
 
 ```bash
-cd terraform/environments/dev
+cd terraform/environments/dev   # prod は environments/prod
 
-# terraform で変更（neon.tf の min/max compute units を編集）
+# terraform で変更（neon.tf の default_endpoint_settings を編集）
 terraform plan
 terraform apply
 ```
 
-`neon.tf` の該当箇所:
+`neon.tf` の該当箇所（`neon_project` の `default_endpoint_settings` ブロック）:
 
 ```hcl
-resource "neon_endpoint" "default" {
-  autoscaling_limit_min_cu = 0.25  # 最小CU
-  autoscaling_limit_max_cu = 2     # 最大CU
+resource "neon_project" "default" {
+  # ...
+  default_endpoint_settings {
+    autoscaling_limit_min_cu = 0.25  # 最小CU
+    autoscaling_limit_max_cu = 2     # 最大CU（prod は 4）
+    suspend_timeout_seconds  = 0     # 常時稼働（auto-suspend 無効）
+  }
 }
 ```
 


### PR DESCRIPTION
## 概要

リリース前の棚卸しとして docs / CLAUDE.md と実インフラの差分を確認し、見つかったドリフトを修正。

## 修正内容

### `docs/runbook.md`
- **Neon CU 変更手順**: `resource "neon_endpoint" "default"` を記載していたが、実際には存在しないリソース。正しくは `neon_project` の `default_endpoint_settings` ブロック。CU 上限も dev=2 / prod=4 に修正（旧記載は「2」固定）。
- **環境情報テーブル**: prod の Neon 識別子 `ep-misty-unit-aoxkoz1d` は実際は**エンドポイント ID** で、dev 側（プロジェクト ID）と粒度が不一致だった。「Neon プロジェクト ID」「Neon エンドポイント」の2行に分け、prod プロジェクト ID `fragrant-poetry-87067174` を記載。

### `CLAUDE.md`
- prod の Neon ID を同様に修正（プロジェクト ID + エンドポイント併記）。
- `terraform/modules/` 一覧に実在する `api_gateway` / `cognito` / `cognito_identity` を追加（従来は cloudfront/ecr/lambda/s3 の4つだけ記載）。
- `terraform/environments/` に `prod` を追加（従来は shared/dev のみ）。

## 確認した結果ドリフトが無かったもの
- CloudFront ディストリビューション ID（`E1LVBAGQ7YS8CR` / `EIA13UUJ41NKO`）→ 実値と一致
- AWS アカウント ID / プロファイル名（aws-setup.md）→ 一致
- `cmd/` のコマンド（datasync / admin / importer / server）→ 実在
- architecture.md の Terraform モジュール表 → 実在する7モジュールと一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)