### PR TITLE
fix: 復習リストで正解してもリストから消えないバグを修正

### DIFF
--- a/app/internal/api/api.gen.go
+++ b/app/internal/api/api.gen.go
@@ -355,8 +355,8 @@ type WrongAnswerQuestion struct {
 	Id          int64   `json:"id"`
 
 	// Images 画像URL
-	Images *[]string `json:"images,omitempty"`
-	Text   string    `json:"text"`
+	Images *[]string    `json:"images,omitempty"`
+	Text   string       `json:"text"`
 	Type   QuestionType `json:"type"`
 
 	// WorkbookId この問題を最後に回答した問題集のID

--- a/app/internal/api/api.gen.go
+++ b/app/internal/api/api.gen.go
@@ -343,10 +343,30 @@ type WorkbooksResponse struct {
 	Workbooks []Workbook `json:"workbooks"`
 }
 
+// WrongAnswerQuestion defines model for WrongAnswerQuestion.
+type WrongAnswerQuestion struct {
+	Choices []string `json:"choices"`
+
+	// Correct 正解の選択肢インデックス
+	Correct *int `json:"correct,omitempty"`
+
+	// Explanation 解説
+	Explanation *string `json:"explanation,omitempty"`
+	Id          int64   `json:"id"`
+
+	// Images 画像URL
+	Images *[]string `json:"images,omitempty"`
+	Text   string    `json:"text"`
+	Type   QuestionType `json:"type"`
+
+	// WorkbookId この問題を最後に回答した問題集のID
+	WorkbookId int64 `json:"workbookId"`
+}
+
 // WrongAnswersResponse defines model for WrongAnswersResponse.
 type WrongAnswersResponse struct {
-	Questions []Question `json:"questions"`
-	Total     int        `json:"total"`
+	Questions []WrongAnswerQuestion `json:"questions"`
+	Total     int                   `json:"total"`
 }
 
 // DeviceID defines model for DeviceID.

--- a/app/internal/db/answers.sql.go
+++ b/app/internal/db/answers.sql.go
@@ -456,10 +456,11 @@ func (q *Queries) ListWrongAnswers(ctx context.Context, arg ListWrongAnswersPara
 
 const listWrongAnswersWithChoices = `-- name: ListWrongAnswersWithChoices :many
 SELECT q.id, qsc.text, qsc.explanation,
-    c.text AS choice_text, c.is_correct, c.choice_index
+    c.text AS choice_text, c.is_correct, c.choice_index,
+    paged.workbook_id
 FROM (
-    SELECT question_id FROM (
-        SELECT DISTINCT ON (question_id) question_id, is_correct
+    SELECT question_id, workbook_id FROM (
+        SELECT DISTINCT ON (question_id) question_id, is_correct, workbook_id
         FROM user_answers
         WHERE user_id = $1
         ORDER BY question_id, answered_at DESC
@@ -487,6 +488,7 @@ type ListWrongAnswersWithChoicesRow struct {
 	ChoiceText  sql.NullString `json:"choice_text"`
 	IsCorrect   sql.NullBool   `json:"is_correct"`
 	ChoiceIndex sql.NullInt32  `json:"choice_index"`
+	WorkbookID  int64          `json:"workbook_id"`
 }
 
 func (q *Queries) ListWrongAnswersWithChoices(ctx context.Context, arg ListWrongAnswersWithChoicesParams) ([]ListWrongAnswersWithChoicesRow, error) {
@@ -505,6 +507,7 @@ func (q *Queries) ListWrongAnswersWithChoices(ctx context.Context, arg ListWrong
 			&i.ChoiceText,
 			&i.IsCorrect,
 			&i.ChoiceIndex,
+			&i.WorkbookID,
 		); err != nil {
 			return nil, err
 		}

--- a/app/internal/handler/answers.go
+++ b/app/internal/handler/answers.go
@@ -267,7 +267,7 @@ func (h *Handler) GetWrongAnswers(ctx context.Context, request api.GetWrongAnswe
 
 	userID, err := h.queries.GetUserByIdentityID(ctx, deviceID)
 	if err == sql.ErrNoRows {
-		return api.GetWrongAnswers200JSONResponse{Questions: []api.Question{}, Total: 0}, nil
+		return api.GetWrongAnswers200JSONResponse{Questions: []api.WrongAnswerQuestion{}, Total: 0}, nil
 	}
 	if err != nil {
 		h.logger.Error("failed to get user", "error", err, "device_id", deviceID)
@@ -290,11 +290,15 @@ func (h *Handler) GetWrongAnswers(ctx context.Context, request api.GetWrongAnswe
 		return nil, err
 	}
 
+	workbookIDMap := map[int64]int64{}
 	flatRows := make([]questionWithChoicesRow, len(rows))
 	for i, r := range rows {
 		flatRows[i] = questionWithChoicesRow{
 			ID: r.ID, Text: r.Text, Explanation: r.Explanation,
 			ChoiceText: r.ChoiceText, IsCorrect: r.IsCorrect, ChoiceIndex: r.ChoiceIndex,
+		}
+		if _, exists := workbookIDMap[r.ID]; !exists {
+			workbookIDMap[r.ID] = r.WorkbookID
 		}
 	}
 	questions := buildQuestionsFromRows(flatRows)
@@ -303,8 +307,22 @@ func (h *Handler) GetWrongAnswers(ctx context.Context, request api.GetWrongAnswe
 		return nil, err
 	}
 
+	wrongAnswerQuestions := make([]api.WrongAnswerQuestion, len(questions))
+	for i, q := range questions {
+		wrongAnswerQuestions[i] = api.WrongAnswerQuestion{
+			Id:          q.Id,
+			Type:        q.Type,
+			Text:        q.Text,
+			Choices:     q.Choices,
+			Correct:     q.Correct,
+			Explanation: q.Explanation,
+			Images:      q.Images,
+			WorkbookId:  workbookIDMap[q.Id],
+		}
+	}
+
 	return api.GetWrongAnswers200JSONResponse{
-		Questions: questions,
+		Questions: wrongAnswerQuestions,
 		Total:     int(total),
 	}, nil
 }

--- a/app/sql/queries/answers.sql
+++ b/app/sql/queries/answers.sql
@@ -48,10 +48,11 @@ LIMIT $2 OFFSET $3;
 
 -- name: ListWrongAnswersWithChoices :many
 SELECT q.id, qsc.text, qsc.explanation,
-    c.text AS choice_text, c.is_correct, c.choice_index
+    c.text AS choice_text, c.is_correct, c.choice_index,
+    paged.workbook_id
 FROM (
-    SELECT question_id FROM (
-        SELECT DISTINCT ON (question_id) question_id, is_correct
+    SELECT question_id, workbook_id FROM (
+        SELECT DISTINCT ON (question_id) question_id, is_correct, workbook_id
         FROM user_answers
         WHERE user_id = $1
         ORDER BY question_id, answered_at DESC

--- a/ios/Rikako/Data/Remote/Response/CategoryListResponse.swift
+++ b/ios/Rikako/Data/Remote/Response/CategoryListResponse.swift
@@ -13,9 +13,7 @@ struct WrongAnswerQuestion: Codable {
     let correct: Int?
     let explanation: String?
     let images: [String]?
-    // workbookId を返さない旧APIでもデコードが失敗してリストが空にならないよう optional にする。
-    // 値が無い場合、復習の回答はその問題集へ正しく帰属できない（旧API配信中の一時的なデグレード）。
-    let workbookId: Int64?
+    let workbookId: Int64
 
     var asQuestion: Question {
         Question(id: id, type: type, text: text, choices: choices, correct: correct, explanation: explanation, images: images)

--- a/ios/Rikako/Data/Remote/Response/CategoryListResponse.swift
+++ b/ios/Rikako/Data/Remote/Response/CategoryListResponse.swift
@@ -13,7 +13,9 @@ struct WrongAnswerQuestion: Codable {
     let correct: Int?
     let explanation: String?
     let images: [String]?
-    let workbookId: Int64
+    // workbookId を返さない旧APIでもデコードが失敗してリストが空にならないよう optional にする。
+    // 値が無い場合、復習の回答はその問題集へ正しく帰属できない（旧API配信中の一時的なデグレード）。
+    let workbookId: Int64?
 
     var asQuestion: Question {
         Question(id: id, type: type, text: text, choices: choices, correct: correct, explanation: explanation, images: images)

--- a/ios/Rikako/Data/Remote/Response/CategoryListResponse.swift
+++ b/ios/Rikako/Data/Remote/Response/CategoryListResponse.swift
@@ -5,7 +5,22 @@ struct CategoryListResponse: Codable {
     let total: Int
 }
 
+struct WrongAnswerQuestion: Codable {
+    let id: Int64
+    let type: Question.QuestionType
+    let text: String
+    let choices: [String]
+    let correct: Int?
+    let explanation: String?
+    let images: [String]?
+    let workbookId: Int64
+
+    var asQuestion: Question {
+        Question(id: id, type: type, text: text, choices: choices, correct: correct, explanation: explanation, images: images)
+    }
+}
+
 struct WrongAnswerListResponse: Codable {
-    let questions: [Question]
+    let questions: [WrongAnswerQuestion]
     let total: Int
 }

--- a/ios/Rikako/Preview/PreviewLearningRepository.swift
+++ b/ios/Rikako/Preview/PreviewLearningRepository.swift
@@ -125,10 +125,10 @@ final class PreviewLearningRepository: LearningRepository {
     }
 
     func fetchWrongAnswers(limit: Int, offset: Int) async throws -> WrongAnswerListResponse {
-        WrongAnswerListResponse(
-            questions: Array(MockData.questions.prefix(limit)),
-            total: min(limit, MockData.questions.count)
-        )
+        let waq = MockData.questions.prefix(limit).map {
+            WrongAnswerQuestion(id: $0.id, type: $0.type, text: $0.text, choices: $0.choices, correct: $0.correct, explanation: $0.explanation, images: $0.images, workbookId: 1)
+        }
+        return WrongAnswerListResponse(questions: Array(waq), total: min(limit, MockData.questions.count))
     }
 
     func fetchAnnouncements() async throws -> [Announcement] {

--- a/ios/Rikako/Screen/Quiz/QuizSource.swift
+++ b/ios/Rikako/Screen/Quiz/QuizSource.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// クイズの出題元。回答をどの問題集に記録するかを決める。
+/// - workbook: 通常プレイ。全問が同じ問題集に属する。
+/// - review: 復習。問題ごとに出身問題集が異なるため、問題ID→問題集IDのマップを持つ。
+enum QuizSource {
+    case workbook(id: Int64)
+    case review(workbookIds: [Int64: Int64])
+
+    var isReview: Bool {
+        if case .review = self { return true }
+        return false
+    }
+
+    func workbookId(for questionId: Int64) -> Int64 {
+        switch self {
+        case .workbook(let id): return id
+        case .review(let map): return map[questionId] ?? 0
+        }
+    }
+
+    /// 回答を問題集ごとにまとめる。2つの送信経路（中断保存・結果画面）で共通利用する。
+    func groupedAnswers(questions: [Question], answers: [Int?]) -> [Int64: [AnswerItem]] {
+        var byWorkbook: [Int64: [AnswerItem]] = [:]
+        for (question, answer) in zip(questions, answers) {
+            guard let choice = answer else { continue }
+            let item = AnswerItem(questionId: question.id, selectedChoice: choice)
+            byWorkbook[workbookId(for: question.id), default: []].append(item)
+        }
+        return byWorkbook
+    }
+}

--- a/ios/Rikako/Screen/Quiz/QuizView.swift
+++ b/ios/Rikako/Screen/Quiz/QuizView.swift
@@ -16,11 +16,12 @@ struct QuizView: View {
     private let allSectionsQuestions: [[Question]]
     private let currentSectionIndex: Int
 
-    init(questions: [Question], workbookTitle: String, workbookId: Int64, allSectionsQuestions: [[Question]] = [], currentSectionIndex: Int = 0) {
+    init(questions: [Question], workbookTitle: String, workbookId: Int64, allSectionsQuestions: [[Question]] = [], currentSectionIndex: Int = 0, questionWorkbookIds: [Int64: Int64]? = nil) {
         _viewModel = State(initialValue: QuizViewModel(
             questions: questions,
             workbookTitle: workbookTitle,
-            workbookId: workbookId
+            workbookId: workbookId,
+            questionWorkbookIds: questionWorkbookIds
         ))
         self.allSectionsQuestions = allSectionsQuestions
         self.currentSectionIndex = currentSectionIndex

--- a/ios/Rikako/Screen/Quiz/QuizView.swift
+++ b/ios/Rikako/Screen/Quiz/QuizView.swift
@@ -16,12 +16,11 @@ struct QuizView: View {
     private let allSectionsQuestions: [[Question]]
     private let currentSectionIndex: Int
 
-    init(questions: [Question], workbookTitle: String, workbookId: Int64, allSectionsQuestions: [[Question]] = [], currentSectionIndex: Int = 0, questionWorkbookIds: [Int64: Int64]? = nil) {
+    init(questions: [Question], workbookTitle: String, source: QuizSource, allSectionsQuestions: [[Question]] = [], currentSectionIndex: Int = 0) {
         _viewModel = State(initialValue: QuizViewModel(
             questions: questions,
             workbookTitle: workbookTitle,
-            workbookId: workbookId,
-            questionWorkbookIds: questionWorkbookIds
+            source: source
         ))
         self.allSectionsQuestions = allSectionsQuestions
         self.currentSectionIndex = currentSectionIndex
@@ -99,7 +98,7 @@ struct QuizView: View {
                 questions: viewModel.questions,
                 answers: viewModel.answers,
                 workbookTitle: viewModel.workbookTitle,
-                workbookId: viewModel.workbookId,
+                source: viewModel.source,
                 allSectionsQuestions: allSectionsQuestions,
                 currentSectionIndex: currentSectionIndex
             )
@@ -294,12 +293,12 @@ struct QuizView: View {
 
 #Preview("問題表示") {
     NavigationStack {
-        QuizView(questions: MockData.questions, workbookTitle: "基礎化学", workbookId: 1)
+        QuizView(questions: MockData.questions, workbookTitle: "基礎化学", source: .workbook(id: 1))
     }
 }
 
 #Preview("画像付き問題") {
     NavigationStack {
-        QuizView(questions: MockData.questionsWithImages, workbookTitle: "基礎化学", workbookId: 1)
+        QuizView(questions: MockData.questionsWithImages, workbookTitle: "基礎化学", source: .workbook(id: 1))
     }
 }

--- a/ios/Rikako/Screen/Quiz/QuizViewModel.swift
+++ b/ios/Rikako/Screen/Quiz/QuizViewModel.swift
@@ -6,8 +6,7 @@ import Observation
 final class QuizViewModel {
     let questions: [Question]
     let workbookTitle: String
-    let workbookId: Int64
-    let questionWorkbookIds: [Int64: Int64]?
+    let source: QuizSource
 
     var currentIndex = 0
     var selectedChoice: Int?
@@ -15,11 +14,10 @@ final class QuizViewModel {
     var answers: [Int?]
     var showResult = false
 
-    init(questions: [Question], workbookTitle: String, workbookId: Int64, questionWorkbookIds: [Int64: Int64]? = nil) {
+    init(questions: [Question], workbookTitle: String, source: QuizSource) {
         self.questions = questions
         self.workbookTitle = workbookTitle
-        self.workbookId = workbookId
-        self.questionWorkbookIds = questionWorkbookIds
+        self.source = source
         self.answers = Array(repeating: nil, count: questions.count)
     }
 
@@ -49,13 +47,7 @@ final class QuizViewModel {
     }
 
     func submitAnswers() async {
-        var byWorkbook: [Int64: [AnswerItem]] = [:]
-        for (question, answer) in zip(questions, answers) {
-            guard let choice = answer else { continue }
-            let item = AnswerItem(questionId: question.id, selectedChoice: choice)
-            let wbId = questionWorkbookIds?[question.id] ?? workbookId
-            byWorkbook[wbId, default: []].append(item)
-        }
+        let byWorkbook = source.groupedAnswers(questions: questions, answers: answers)
         guard !byWorkbook.isEmpty else { return }
         for (wbId, items) in byWorkbook {
             _ = try? await AppContainer.shared.learningUseCases.submitAnswers.execute(

--- a/ios/Rikako/Screen/Quiz/QuizViewModel.swift
+++ b/ios/Rikako/Screen/Quiz/QuizViewModel.swift
@@ -7,6 +7,7 @@ final class QuizViewModel {
     let questions: [Question]
     let workbookTitle: String
     let workbookId: Int64
+    let questionWorkbookIds: [Int64: Int64]?
 
     var currentIndex = 0
     var selectedChoice: Int?
@@ -14,10 +15,11 @@ final class QuizViewModel {
     var answers: [Int?]
     var showResult = false
 
-    init(questions: [Question], workbookTitle: String, workbookId: Int64) {
+    init(questions: [Question], workbookTitle: String, workbookId: Int64, questionWorkbookIds: [Int64: Int64]? = nil) {
         self.questions = questions
         self.workbookTitle = workbookTitle
         self.workbookId = workbookId
+        self.questionWorkbookIds = questionWorkbookIds
         self.answers = Array(repeating: nil, count: questions.count)
     }
 
@@ -47,14 +49,19 @@ final class QuizViewModel {
     }
 
     func submitAnswers() async {
-        let answerItems = zip(questions, answers).compactMap { question, answer -> AnswerItem? in
-            guard let choice = answer else { return nil }
-            return AnswerItem(questionId: question.id, selectedChoice: choice)
+        var byWorkbook: [Int64: [AnswerItem]] = [:]
+        for (question, answer) in zip(questions, answers) {
+            guard let choice = answer else { continue }
+            let item = AnswerItem(questionId: question.id, selectedChoice: choice)
+            let wbId = questionWorkbookIds?[question.id] ?? workbookId
+            byWorkbook[wbId, default: []].append(item)
         }
-        guard !answerItems.isEmpty else { return }
-        _ = try? await AppContainer.shared.learningUseCases.submitAnswers.execute(
-            workbookId: workbookId,
-            answers: answerItems
-        )
+        guard !byWorkbook.isEmpty else { return }
+        for (wbId, items) in byWorkbook {
+            _ = try? await AppContainer.shared.learningUseCases.submitAnswers.execute(
+                workbookId: wbId,
+                answers: items
+            )
+        }
     }
 }

--- a/ios/Rikako/Screen/Result/ResultView.swift
+++ b/ios/Rikako/Screen/Result/ResultView.swift
@@ -13,7 +13,7 @@ struct ResultView: View {
         questions: [Question],
         answers: [Int?],
         workbookTitle: String,
-        workbookId: Int64,
+        source: QuizSource,
         allSectionsQuestions: [[Question]] = [],
         currentSectionIndex: Int = 0
     ) {
@@ -21,7 +21,7 @@ struct ResultView: View {
             questions: questions,
             answers: answers,
             workbookTitle: workbookTitle,
-            workbookId: workbookId
+            source: source
         ))
         self.allSectionsQuestions = allSectionsQuestions
         self.currentSectionIndex = currentSectionIndex
@@ -62,7 +62,7 @@ struct ResultView: View {
             QuizView(
                 questions: sections.isEmpty ? viewModel.questions : sections[idx],
                 workbookTitle: viewModel.workbookTitle,
-                workbookId: viewModel.workbookId,
+                source: viewModel.source,
                 allSectionsQuestions: sections,
                 currentSectionIndex: idx
             )
@@ -71,7 +71,7 @@ struct ResultView: View {
             QuizView(
                 questions: wrongQuestions,
                 workbookTitle: viewModel.workbookTitle,
-                workbookId: viewModel.workbookId
+                source: viewModel.source
             )
         }
         .task {
@@ -84,7 +84,8 @@ struct ResultView: View {
     }
 
     private func loadSections() async {
-        guard let detail = try? await AppContainer.shared.learningUseCases.fetchWorkbookDetail.execute(id: viewModel.workbookId) else { return }
+        guard case .workbook(let workbookId) = viewModel.source else { return }
+        guard let detail = try? await AppContainer.shared.learningUseCases.fetchWorkbookDetail.execute(id: workbookId) else { return }
         let chunkSize = 10
         let total = detail.questions.count
         loadedSections = stride(from: 0, to: total, by: chunkSize).map { start in
@@ -201,19 +202,23 @@ struct ResultView: View {
         .clipShape(RoundedRectangle(cornerRadius: 20))
     }
 
+    @ViewBuilder
     private var continueButton: some View {
-        let sections = effectiveSections
-        let sectionNumber = sections.isEmpty ? 1 : nextSectionIndex + 1
-        return Button {
-            showContinueQuiz = true
-        } label: {
-            Text(sections.isEmpty ? "次のチャプターを勉強する" : "Chapter \(sectionNumber) を勉強する")
-                .font(.headline)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color(.main))
-                .foregroundStyle(.white)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
+        // 復習は複数問題集を横断するため「次のチャプター」が一意に決まらない → 非表示
+        if !viewModel.source.isReview {
+            let sections = effectiveSections
+            let sectionNumber = sections.isEmpty ? 1 : nextSectionIndex + 1
+            Button {
+                showContinueQuiz = true
+            } label: {
+                Text(sections.isEmpty ? "次のチャプターを勉強する" : "Chapter \(sectionNumber) を勉強する")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color(.main))
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
         }
     }
 
@@ -358,35 +363,35 @@ private extension Array {
 
 #Preview("100% 全問正解") {
     NavigationStack {
-        ResultView(questions: MockData.questions, answers: [0, 1, 2, 1, 2], workbookTitle: "基礎化学", workbookId: 1)
+        ResultView(questions: MockData.questions, answers: [0, 1, 2, 1, 2], workbookTitle: "基礎化学", source: .workbook(id: 1))
             .environment(AppState.shared)
     }
 }
 
 #Preview("80%") {
     NavigationStack {
-        ResultView(questions: MockData.questions, answers: [0, 1, 2, 0, 2], workbookTitle: "基礎化学", workbookId: 1)
+        ResultView(questions: MockData.questions, answers: [0, 1, 2, 0, 2], workbookTitle: "基礎化学", source: .workbook(id: 1))
             .environment(AppState.shared)
     }
 }
 
 #Preview("60%") {
     NavigationStack {
-        ResultView(questions: MockData.questions, answers: [0, 1, 0, 0, 2], workbookTitle: "基礎化学", workbookId: 1)
+        ResultView(questions: MockData.questions, answers: [0, 1, 0, 0, 2], workbookTitle: "基礎化学", source: .workbook(id: 1))
             .environment(AppState.shared)
     }
 }
 
 #Preview("40%") {
     NavigationStack {
-        ResultView(questions: MockData.questions, answers: [0, 0, 0, 0, 2], workbookTitle: "基礎化学", workbookId: 1)
+        ResultView(questions: MockData.questions, answers: [0, 0, 0, 0, 2], workbookTitle: "基礎化学", source: .workbook(id: 1))
             .environment(AppState.shared)
     }
 }
 
 #Preview("20%") {
     NavigationStack {
-        ResultView(questions: MockData.questions, answers: [0, 0, 0, 0, 0], workbookTitle: "基礎化学", workbookId: 1)
+        ResultView(questions: MockData.questions, answers: [0, 0, 0, 0, 0], workbookTitle: "基礎化学", source: .workbook(id: 1))
             .environment(AppState.shared)
     }
 }

--- a/ios/Rikako/Screen/Result/ResultViewModel.swift
+++ b/ios/Rikako/Screen/Result/ResultViewModel.swift
@@ -16,15 +16,15 @@ final class ResultViewModel {
     let questions: [Question]
     let answers: [Int?]
     let workbookTitle: String
-    let workbookId: Int64
+    let source: QuizSource
 
     private(set) var didSubmit = false
 
-    init(questions: [Question], answers: [Int?], workbookTitle: String, workbookId: Int64) {
+    init(questions: [Question], answers: [Int?], workbookTitle: String, source: QuizSource) {
         self.questions = questions
         self.answers = answers
         self.workbookTitle = workbookTitle
-        self.workbookId = workbookId
+        self.source = source
     }
 
     var correctCount: Int {
@@ -83,19 +83,18 @@ final class ResultViewModel {
     }
 
     private func submitAnswersToServer() async {
-        let answerItems = zip(questions, answers).compactMap { question, answer -> AnswerItem? in
-            guard let choice = answer else { return nil }
-            return AnswerItem(questionId: question.id, selectedChoice: choice)
-        }
-        guard !answerItems.isEmpty else { return }
+        let byWorkbook = source.groupedAnswers(questions: questions, answers: answers)
+        guard !byWorkbook.isEmpty else { return }
 
-        do {
-            _ = try await AppContainer.shared.learningUseCases.submitAnswers.execute(
-                workbookId: workbookId,
-                answers: answerItems
-            )
-        } catch {
-            // ログ送信失敗はサイレントに無視（ユーザー体験を損なわない）
+        for (wbId, items) in byWorkbook {
+            do {
+                _ = try await AppContainer.shared.learningUseCases.submitAnswers.execute(
+                    workbookId: wbId,
+                    answers: items
+                )
+            } catch {
+                // ログ送信失敗はサイレントに無視（ユーザー体験を損なわない）
+            }
         }
     }
 }

--- a/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
+++ b/ios/Rikako/Screen/StudyHome/StudyHomeView.swift
@@ -81,7 +81,7 @@ struct StudyHomeView: View {
                     QuizView(
                         questions: config.questions,
                         workbookTitle: config.workbookTitle,
-                        workbookId: config.workbookId,
+                        source: .workbook(id: config.workbookId),
                         allSectionsQuestions: config.allSectionsQuestions,
                         currentSectionIndex: config.currentSectionIndex
                     )

--- a/ios/Rikako/Screen/WorkbookDetailView.swift
+++ b/ios/Rikako/Screen/WorkbookDetailView.swift
@@ -51,7 +51,7 @@ struct WorkbookDetailView: View {
                     }
 
                     Section {
-                        NavigationLink(destination: QuizView(questions: workbook.questions, workbookTitle: workbook.title, workbookId: workbook.id)) {
+                        NavigationLink(destination: QuizView(questions: workbook.questions, workbookTitle: workbook.title, source: .workbook(id: workbook.id))) {
                             Label("この問題集を解く", systemImage: "play.fill")
                                 .font(.headline)
                                 .frame(maxWidth: .infinity)

--- a/ios/Rikako/Screen/WrongAnswersView.swift
+++ b/ios/Rikako/Screen/WrongAnswersView.swift
@@ -50,8 +50,7 @@ struct WrongAnswersView: View {
                         NavigationLink(destination: QuizView(
                             questions: questions,
                             workbookTitle: "復習",
-                            workbookId: wrongAnswerQuestions.first?.workbookId ?? 0,
-                            questionWorkbookIds: workbookIdMap
+                            source: .review(workbookIds: workbookIdMap)
                         )) {
                             Label("復習する", systemImage: "arrow.counterclockwise")
                                 .font(.headline)

--- a/ios/Rikako/Screen/WrongAnswersView.swift
+++ b/ios/Rikako/Screen/WrongAnswersView.swift
@@ -46,9 +46,7 @@ struct WrongAnswersView: View {
 
                     Section {
                         let questions = wrongAnswerQuestions.map(\.asQuestion)
-                        let workbookIdMap = Dictionary(uniqueKeysWithValues: wrongAnswerQuestions.compactMap { waq in
-                            waq.workbookId.map { (waq.id, $0) }
-                        })
+                        let workbookIdMap = Dictionary(uniqueKeysWithValues: wrongAnswerQuestions.map { ($0.id, $0.workbookId) })
                         NavigationLink(destination: QuizView(
                             questions: questions,
                             workbookTitle: "復習",

--- a/ios/Rikako/Screen/WrongAnswersView.swift
+++ b/ios/Rikako/Screen/WrongAnswersView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct WrongAnswersView: View {
-    @State private var questions: [Question] = []
+    @State private var wrongAnswerQuestions: [WrongAnswerQuestion] = []
     @State private var total = 0
     @State private var isLoading = true
 
@@ -9,7 +9,7 @@ struct WrongAnswersView: View {
         Group {
             if isLoading {
                 ProgressView("読み込み中...")
-            } else if questions.isEmpty {
+            } else if wrongAnswerQuestions.isEmpty {
                 ContentUnavailableView {
                     Label("間違えた問題はありません", systemImage: "checkmark.circle")
                 } description: {
@@ -23,7 +23,7 @@ struct WrongAnswersView: View {
                     }
 
                     Section("問題一覧") {
-                        ForEach(Array(questions.enumerated()), id: \.element.id) { index, question in
+                        ForEach(Array(wrongAnswerQuestions.enumerated()), id: \.element.id) { index, waq in
                             VStack(alignment: .leading, spacing: 12) {
                                 HStack {
                                     Text("Q\(index + 1)")
@@ -33,11 +33,11 @@ struct WrongAnswersView: View {
                                         .frame(width: 32, height: 32)
                                         .background(Color.red)
                                         .clipShape(Circle())
-                                    Text(question.text)
+                                    Text(waq.text)
                                         .lineLimit(2)
                                 }
 
-                                if let images = question.images, !images.isEmpty {
+                                if let images = waq.images, !images.isEmpty {
                                     QuestionImageSection(imageURLs: images)
                                 }
                             }
@@ -45,7 +45,14 @@ struct WrongAnswersView: View {
                     }
 
                     Section {
-                        NavigationLink(destination: QuizView(questions: questions, workbookTitle: "復習", workbookId: 0)) {
+                        let questions = wrongAnswerQuestions.map(\.asQuestion)
+                        let workbookIdMap = Dictionary(uniqueKeysWithValues: wrongAnswerQuestions.map { ($0.id, $0.workbookId) })
+                        NavigationLink(destination: QuizView(
+                            questions: questions,
+                            workbookTitle: "復習",
+                            workbookId: wrongAnswerQuestions.first?.workbookId ?? 0,
+                            questionWorkbookIds: workbookIdMap
+                        )) {
                             Label("復習する", systemImage: "arrow.counterclockwise")
                                 .font(.headline)
                                 .frame(maxWidth: .infinity)
@@ -62,7 +69,7 @@ struct WrongAnswersView: View {
     private func load() async {
         isLoading = true
         let response = try? await AppContainer.shared.learningUseCases.fetchWrongAnswers.execute(limit: 50, offset: 0)
-        questions = response?.questions ?? []
+        wrongAnswerQuestions = response?.questions ?? []
         total = response?.total ?? 0
         isLoading = false
     }

--- a/ios/Rikako/Screen/WrongAnswersView.swift
+++ b/ios/Rikako/Screen/WrongAnswersView.swift
@@ -46,7 +46,9 @@ struct WrongAnswersView: View {
 
                     Section {
                         let questions = wrongAnswerQuestions.map(\.asQuestion)
-                        let workbookIdMap = Dictionary(uniqueKeysWithValues: wrongAnswerQuestions.map { ($0.id, $0.workbookId) })
+                        let workbookIdMap = Dictionary(uniqueKeysWithValues: wrongAnswerQuestions.compactMap { waq in
+                            waq.workbookId.map { (waq.id, $0) }
+                        })
                         NavigationLink(destination: QuizView(
                             questions: questions,
                             workbookTitle: "復習",

--- a/ios/Rikako/Screen/WrongAnswersView.swift
+++ b/ios/Rikako/Screen/WrongAnswersView.swift
@@ -4,11 +4,22 @@ struct WrongAnswersView: View {
     @State private var wrongAnswerQuestions: [WrongAnswerQuestion] = []
     @State private var total = 0
     @State private var isLoading = true
+    @State private var errorMessage: String?
 
     var body: some View {
         Group {
             if isLoading {
                 ProgressView("読み込み中...")
+            } else if let errorMessage {
+                ContentUnavailableView {
+                    Label("読み込みエラー", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("再読み込み") {
+                        Task { await load() }
+                    }
+                }
             } else if wrongAnswerQuestions.isEmpty {
                 ContentUnavailableView {
                     Label("間違えた問題はありません", systemImage: "checkmark.circle")
@@ -67,10 +78,16 @@ struct WrongAnswersView: View {
 
     private func load() async {
         isLoading = true
-        let response = try? await AppContainer.shared.learningUseCases.fetchWrongAnswers.execute(limit: 50, offset: 0)
-        wrongAnswerQuestions = response?.questions ?? []
-        total = response?.total ?? 0
-        isLoading = false
+        errorMessage = nil
+        do {
+            let response = try await AppContainer.shared.learningUseCases.fetchWrongAnswers.execute(limit: 50, offset: 0)
+            wrongAnswerQuestions = response.questions
+            total = response.total
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
     }
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1087,6 +1087,43 @@ components:
         total:
           type: integer
 
+    WrongAnswerQuestion:
+      type: object
+      required:
+        - id
+        - type
+        - text
+        - choices
+        - workbookId
+      properties:
+        id:
+          type: integer
+          format: int64
+        type:
+          type: string
+          enum:
+            - single_choice
+        text:
+          type: string
+        choices:
+          type: array
+          items:
+            type: string
+        correct:
+          type: integer
+          description: 正解の選択肢インデックス
+        explanation:
+          type: string
+          description: 解説
+        images:
+          type: array
+          items:
+            type: string
+        workbookId:
+          type: integer
+          format: int64
+          description: この問題を最後に回答した問題集のID
+
     WrongAnswersResponse:
       type: object
       required:
@@ -1096,7 +1133,7 @@ components:
         questions:
           type: array
           items:
-            $ref: '#/components/schemas/Question'
+            $ref: '#/components/schemas/WrongAnswerQuestion'
         total:
           type: integer
 


### PR DESCRIPTION
## 原因

`WrongAnswersView` で「復習する」ボタンを押したとき、`QuizView` に `workbookId: 0` がハードコードされていた。

```swift
// Before（バグ）
QuizView(questions: questions, workbookTitle: "復習", workbookId: 0)
```

これにより `POST /answers` がバックエンドの `WorkbookExists(0)` チェックで **400 エラー**になり、正解が `user_answers` に保存されなかった。保存されないので `GET /users/me/wrong-answers` のクエリ（`DISTINCT ON (question_id) ORDER BY answered_at DESC`）は古い不正解レコードを返し続け、リストから消えなかった。

## 変更内容

### バックエンド (`app/`)
`GET /users/me/wrong-answers` のレスポンスに `workbookId` を追加。iOSが正しい値を取得できるようにした。

- `openapi.yaml`: `WrongAnswerQuestion` スキーマを新規追加（`Question` + `workbookId`）
- `app/sql/queries/answers.sql`: `DISTINCT ON` に `workbook_id` を追加
- `app/internal/db/answers.sql.go`: 生成コードに `WorkbookID` フィールドとScanを追加
- `app/internal/api/api.gen.go`: `WrongAnswerQuestion` 型を追加、`WrongAnswersResponse` を更新
- `app/internal/handler/answers.go`: 各問題に `workbook_id` を付加して返却

### iOS (`ios/`)
`workbookId: 0` のハードコードを撤廃。問題集ごとに正しい `workbookId` で回答を送信するよう修正。

- `CategoryListResponse.swift`: `WrongAnswerQuestion` 型を追加（`workbookId` フィールドあり）
- `WrongAnswersView.swift`: `WrongAnswerQuestion` を使用し、各問題の `workbookId` を `QuizView` に渡すよう変更
- `QuizViewModel.swift`: `questionWorkbookIds` を追加し、`submitAnswers()` で問題集単位に分けて送信
- `QuizView.swift`: `questionWorkbookIds` 引数を追加（既存呼び出しはデフォルト値 `nil` で後方互換）
- `PreviewLearningRepository.swift`: モックデータを新しい型に対応

## テスト計画

- [ ] 問題集で問題を間違える
- [ ] 学習記録 → 復習リストで問題が表示されることを確認
- [ ] 「復習する」から正解する
- [ ] 復習リストに戻ったとき、正解した問題が消えていることを確認
- [ ] 複数の問題集からの間違い問題が混在しても正常に動作することを確認
- [ ] 通常の問題集プレイ（`workbookId` 指定）が引き続き正常動作することを確認

https://claude.ai/code/session_01A6nVRuQUPX6sqgWgisSLon