### PR TITLE
解答一覧画面で問題文が省略されないよう修正

### DIFF
--- a/ios/Rikako/Screen/Result/ResultView.swift
+++ b/ios/Rikako/Screen/Result/ResultView.swift
@@ -174,7 +174,7 @@ struct ResultView: View {
                 NavigationLink {
                     ResultQuestionDetailView(row: row)
                 } label: {
-                    HStack {
+                    HStack(alignment: .top) {
                         Image(row.isCorrect ? .resultCorrect : .resultDiscorrect)
                             .resizable()
                             .frame(width: 28, height: 28)
@@ -183,7 +183,6 @@ struct ResultView: View {
                             .font(.subheadline.bold())
                             .frame(width: 32)
                         Text(row.question.text)
-                            .lineLimit(1)
                             .foregroundStyle(.secondary)
                         Spacer()
                         Image(.resultNext)


### PR DESCRIPTION
## 概要

解答一覧画面で問題文が省略されてしまっていた問題を修正。

## 変更内容

`ios/Rikako/Screen/Result/ResultView.swift`

- `.lineLimit(1)` を削除 → 問題文が全文表示されるようになります
- `HStack` のアライメントを `.top` に変更 → 問題文が複数行になったときにアイコンや矢印が上揃えになりレイアウトが崩れません

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao4og2V887Vtz7CtGsdy1B)_