### PR TITLE
docs+ci: dev DB接続(SSM/lib/pq)の注意追記とplan-datasyncの偽陽性修正

### DIFF
--- a/.github/workflows/plan-datasync.yml
+++ b/.github/workflows/plan-datasync.yml
@@ -38,7 +38,11 @@ jobs:
         id: plan
         working-directory: app
         run: |
-          ./datasync -data ../data -env dev plan 2>&1 | tail -n +2 > ../datasync-plan.txt
+          set -o pipefail
+          # pipefail でパイプ内の datasync の失敗を検知する（tee で出力はCIログにも残す）
+          ./datasync -data ../data -env dev plan 2>&1 | tee datasync-plan-full.txt
+          # 1行目は接続先URL（DB接続文字列）を含むため除外してコメント用に書き出す
+          tail -n +2 datasync-plan-full.txt > ../datasync-plan.txt
 
       - name: Comment on PR
         uses: actions/github-script@v9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,9 +309,14 @@ iOSアプリはLambda APIではなく、S3上の静的JSONをCloudFront経由で
 
 ### 配信フロー
 1. `data/` のYAMLを編集
-2. `cd app && go run ./cmd/importer -data ../data` でDBに同期
-3. `curl -X POST https://admin.dev.rikako.org/publish` でDB → S3にJSON書き出し
+2. `cd app && AWS_PROFILE=rikako-development-sso go run ./cmd/datasync -data ../data -env dev apply` でNeon dev DBに同期（差分は `apply` を `plan` に変えて事前確認）
+3. `curl -u 'ユーザー名:パスワード' -X POST https://admin.dev.rikako.org/api/publish` でDB → S3にJSON書き出し（管理APIは `/api` 配下・Basic Auth 必須。`/publish` 直下はフロントエンドSPAに当たるので注意）
 4. CloudFrontが60秒以内に新JSONを配信
+
+> **dev DB接続の注意**
+> - `datasync -env dev` は SSM `/rikako/dev/database-url` から接続URLを取得する。アプリ/datasync の DB ドライバは **lib/pq** で、`channel_binding` パラメータ非対応。SSM の値は **pooler ホスト + `?sslmode=require`**（`channel_binding=require` は付けない）にすること。直接エンドポイントだと `password authentication failed` になりやすい。
+> - SSM の `database-url` は Terraform 管理（Neon connection_uri から登録）。手動更新すると次の `terraform apply` で巻き戻る恐れがあるため、恒久対処は Terraform/Neon provider 側を現行値に整合させる。
+> - `.github/workflows/plan-datasync.yml` の plan ステップは `./datasync ... | tail` とパイプしており、datasync の非ゼロ終了を握り潰して**DB接続失敗でもCIが緑になる**既知の不具合がある（`set -o pipefail` 等で要修正）。
 
 ### S3上のJSON構造
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ iOSアプリはLambda APIではなく、S3上の静的JSONをCloudFront経由で
 
 ### 配信フロー
 1. `data/` のYAMLを編集
-2. `cd app && AWS_PROFILE=rikako-development-sso go run ./cmd/datasync -data ../data -env dev apply` でNeon dev DBに同期（差分は `apply` を `plan` に変えて事前確認）
+2. `cd app && go run ./cmd/datasync -data ../data -env dev apply` でNeon dev DBに同期（事前に `AWS_PROFILE` 設定 + `aws sso login` が必要。[AWS CLI セットアップ](docs/aws-setup.md) 参照。差分は `apply` を `plan` に変えて事前確認）
 3. `curl -u 'ユーザー名:パスワード' -X POST https://admin.dev.rikako.org/api/publish` でDB → S3にJSON書き出し（管理APIは `/api` 配下・Basic Auth 必須。`/publish` 直下はフロントエンドSPAに当たるので注意）
 4. CloudFrontが60秒以内に新JSONを配信
 

--- a/docs/datasync.md
+++ b/docs/datasync.md
@@ -141,3 +141,14 @@ workbooks:
 - apply はトランザクション内で実行されるため、途中でエラーが発生した場合はロールバックされます
 - 明示的IDでINSERTするため、apply後にシーケンス（auto increment）は自動でリセットされます
 - `choices` が空の問題では `correct` の差分比較はスキップされます
+
+## dev環境への接続でハマる点
+
+- **DBドライバは lib/pq**。lib/pq は `channel_binding` パラメータを解釈できないため、接続文字列に `channel_binding=require` を含めると接続に失敗する。`?sslmode=require` のみにすること（Neonのコンソールが提示する `psql` 用URLには `channel_binding=require` が付いているのでそのまま使わない）。
+- dev Neon は **pooler ホスト**（`ep-...-pooler.<region>.aws.neon.tech`）を使う。直接エンドポイントだと `password authentication failed for user 'rikako_owner'` になりやすい。
+- 接続URLは SSM `/rikako/dev/database-url`（SecureString）から取得し、これは **Terraform 管理**（Neon `connection_uri` から登録）。Neon 側でロールパスワードが変わると SSM がズレて全接続が認証失敗するので、`terraform apply` で再登録するか、暫定で `aws ssm put-parameter --overwrite` で更新する（手動更新は次の apply で巻き戻る点に注意）。
+- `DATABASE_URL` 環境変数を直接渡せば `--env` より優先される。SSM がズレているときの暫定回避にも使える。
+
+## CI（plan-datasync）の既知の不具合
+
+`.github/workflows/plan-datasync.yml` の plan 実行ステップは `./datasync ... plan 2>&1 | tail -n +2 > ...` とパイプしているため、datasync が非ゼロ終了してもパイプ末尾の `tail` の終了コードでステップが成功扱いになる。**DB接続失敗（認証エラー）でもCIが緑になり、PRコメントにエラー文だけが載る**ため気づきにくい。`set -o pipefail` を入れるか、中間ファイルに落としてから tail する形に直すこと。


### PR DESCRIPTION
## 概要
dev環境のデータ反映フロー(datasync)でハマった点をドキュメント化し、CIの偽陽性バグを修正します。
PR #208(化学式整形)を dev へ反映する作業中に判明した内容です。

## 背景
- SSM `/rikako/dev/database-url` のパスワードが Neon 側ローテートとズレて古いままになっており、`datasync -env dev` も管理Lambda(コールドスタートのinit)も DB 認証失敗していた（管理APIが502になっていた）。
- ところが `plan-datasync.yml` の plan ステップが `./datasync ... | tail` とパイプしていたため、datasync の失敗を握り潰して **CIは緑** になっており、長期間気づけなかった。

## 変更内容
### docs
- `CLAUDE.md` コンテンツ配信フローを修正・補足
  - 同期コマンドを `importer` → **`datasync -env dev`** に修正
  - publish URL を `/publish` → **`/api/publish`（Basic Auth必須）** に修正（`/publish` 直下はフロントエンドSPA）
  - dev DB接続の注意（lib/pqは`channel_binding`非対応 / poolerホスト+`sslmode=require` / SSMはTerraform管理でズレに注意 / CI偽陽性）を追記
- `docs/datasync.md` に同内容の「dev接続でハマる点」「CIの既知の不具合」節を追記

### ci
- `.github/workflows/plan-datasync.yml`: `set -o pipefail` を入れ、`tee` で出力をログに残しつつ datasync の非ゼロ終了でジョブを失敗させるよう修正

## 補足
- SSMの値は暫定で `aws ssm put-parameter --overwrite`(Version 2) で現行パスワードに更新済み。**Terraform管理のため、Terraform/Neon provider 側の整合は別途必要**（次の apply で巻き戻り得る）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)