### PR TITLE
解答詳細画面に「AIに質問する」ボタンを追加

### DIFF
--- a/ios/Rikako/Screen/Result/ResultView.swift
+++ b/ios/Rikako/Screen/Result/ResultView.swift
@@ -255,6 +255,7 @@ struct ResultView: View {
 
 private struct ResultQuestionDetailView: View {
     let row: ResultViewModel.QuestionResultRow
+    @State private var showAIChat = false
 
     var body: some View {
         ScrollView {
@@ -329,11 +330,33 @@ private struct ResultQuestionDetailView: View {
                     .background(Color(.secondarySystemBackground))
                     .clipShape(RoundedRectangle(cornerRadius: 20))
                 }
+
+                Button {
+                    showAIChat = true
+                } label: {
+                    Label("AIに質問する", systemImage: "sparkles")
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color(.main).opacity(0.1))
+                        .foregroundStyle(Color(.main))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
             }
             .padding()
         }
         .navigationTitle("Q\(row.index + 1)")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showAIChat) {
+            NavigationStack {
+                AIChatView(question: row.question, selectedChoice: row.selectedAnswer ?? row.question.correctIndex)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("閉じる") { showAIChat = false }
+                        }
+                    }
+            }
+        }
     }
 
     private func backgroundColor(for index: Int) -> Color {


### PR DESCRIPTION
## 概要

解答結果一覧（`ResultView` の「解答一覧」）から遷移する**解答詳細画面（`ResultQuestionDetailView`）**でも、AIに質問できるようにしました。

これまでクイズ中の解説画面（`QuizView`）にしか「AIに質問する」ボタンが無く、復習時の解答詳細画面からはAIに質問できませんでした。

## 変更内容

- `ResultQuestionDetailView` に `@State showAIChat` を追加
- 解説セクションの下に「AIに質問する」ボタンを配置（正解・不正解どちらの問題でも表示）
- ボタンタップで既存の `AIChatView` をシート表示
- 未解答（`selectedAnswer == nil`）の場合は `correctIndex` にフォールバック（`QuizView` と同じ挙動）

既存の `AIChatView(question:selectedChoice:)` を再利用しており、新規ファイル・新規コンポーネントはありません。

## 動作確認

- [ ] `ResultView` の Preview で解答一覧 → 詳細 → 「AIに質問する」ボタン表示を確認
- [ ] ボタンから `AIChatView` がシート表示され、「閉じる」で閉じられること
- [ ] 対象問題の内容が引き継がれていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)