### PR TITLE
AIチャットの最大往復数を10回から5回に削減

### DIFF
--- a/app/internal/handler/chat.go
+++ b/app/internal/handler/chat.go
@@ -10,7 +10,7 @@ import (
 	"github.com/takoikatakotako/rikako/internal/openai"
 )
 
-const maxTurns = 10
+const maxTurns = 5
 const maxExplanationLen = 2000
 
 func (h *Handler) ChatWithQuestion(ctx context.Context, request api.ChatWithQuestionRequestObject) (api.ChatWithQuestionResponseObject, error) {
@@ -27,7 +27,7 @@ func (h *Handler) ChatWithQuestion(ctx context.Context, request api.ChatWithQues
 		}
 	}
 	if userTurns > maxTurns {
-		return api.ChatWithQuestion400JSONResponse{Code: "TURN_LIMIT_EXCEEDED", Message: "最大10往復を超えています"}, nil
+		return api.ChatWithQuestion400JSONResponse{Code: "TURN_LIMIT_EXCEEDED", Message: "最大5往復を超えています"}, nil
 	}
 	if messages[len(messages)-1].Role != api.User {
 		return api.ChatWithQuestion400JSONResponse{Code: "INVALID_PARAMETER", Message: "最後のメッセージはuserである必要があります"}, nil

--- a/ios/Rikako/Screen/AIChat/AIChatViewModel.swift
+++ b/ios/Rikako/Screen/AIChat/AIChatViewModel.swift
@@ -17,7 +17,7 @@ final class AIChatViewModel {
     let question: Question
     let selectedChoice: Int
     private(set) var messages: [AIChatMessage] = []
-    private(set) var remainingTurns: Int = 10
+    private(set) var remainingTurns: Int = 5
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     var inputText: String = ""


### PR DESCRIPTION
## 概要

AIチャットの往復数が10回では少し多いため、5回に削減します。

## 変更内容

- `app/internal/handler/chat.go`: `maxTurns` を `10` → `5`、エラーメッセージ「最大10往復」→「最大5往復」
- `ios/Rikako/Screen/AIChat/AIChatViewModel.swift`: `remainingTurns` の初期表示値を `10` → `5`

往復数の実質的な上限はサーバー側 `maxTurns` で決まり（送信後 `response.remainingTurns` でクライアントが上書きされる）、iOS の初期値は初回送信前の「残りN回」表示を揃えるための変更です。

## 動作確認

- [ ] `go build ./internal/handler/` が通ること（確認済み）
- [ ] チャット画面の初期表示が「残り5回」になること
- [ ] 5往復目以降に送信できなくなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)