### PR TITLE
公開APIのp99レイテンシアラームからAIチャットを除外

### DIFF
--- a/app/internal/logging/metrics.go
+++ b/app/internal/logging/metrics.go
@@ -1,0 +1,65 @@
+package logging
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+// chatRoutePath は OpenAI API を同期的に呼び出すため遅延が大きく、
+// 公開 API の p99 レイテンシメトリクスから除外するルートパターン。
+const chatRoutePath = "/questions/:questionId/chat"
+
+// metricNamespace / latencyMetricName は CloudWatch EMF で生成するカスタム
+// メトリクスの名前空間・メトリクス名。p99 レイテンシアラームから参照する。
+const (
+	metricNamespace   = "Rikako/PublicAPI"
+	latencyMetricName = "RequestLatency"
+)
+
+type emfMetricDefinition struct {
+	Name string `json:"Name"`
+	Unit string `json:"Unit"`
+}
+
+type emfDirective struct {
+	Namespace  string                `json:"Namespace"`
+	Dimensions [][]string            `json:"Dimensions"`
+	Metrics    []emfMetricDefinition `json:"Metrics"`
+}
+
+type emfMetadata struct {
+	Timestamp         int64          `json:"Timestamp"`
+	CloudWatchMetrics []emfDirective `json:"CloudWatchMetrics"`
+}
+
+// emitLatencyMetric はリクエストのレイテンシを CloudWatch EMF 形式で stdout に
+// 出力する。Lambda 実行環境（AWS_LAMBDA_FUNCTION_NAME 設定時）でのみ出力し、
+// チャットルートは遅延が想定内のため除外する。
+func emitLatencyMetric(routePath string, latency time.Duration) {
+	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") == "" {
+		return
+	}
+	if routePath == chatRoutePath {
+		return
+	}
+
+	doc := map[string]any{
+		"_aws": emfMetadata{
+			Timestamp: time.Now().UnixMilli(),
+			CloudWatchMetrics: []emfDirective{{
+				Namespace:  metricNamespace,
+				Dimensions: [][]string{{"Service"}},
+				Metrics:    []emfMetricDefinition{{Name: latencyMetricName, Unit: "Milliseconds"}},
+			}},
+		},
+		"Service":         "public-api",
+		latencyMetricName: float64(latency.Microseconds()) / 1000.0,
+	}
+
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return
+	}
+	os.Stdout.Write(append(b, '\n'))
+}

--- a/app/internal/logging/middleware.go
+++ b/app/internal/logging/middleware.go
@@ -22,6 +22,9 @@ func RequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 			req := c.Request()
 			status := c.Response().Status
 
+			// p99 レイテンシ用のカスタムメトリクスを EMF で出力（チャットは除外）
+			emitLatencyMetric(c.Path(), latency)
+
 			attrs := []slog.Attr{
 				slog.String("method", req.Method),
 				slog.String("path", req.URL.Path),

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -318,6 +318,22 @@ aws logs filter-log-events \
 # 5. 必要に応じてロールバック（→ 2. ロールバック手順）
 ```
 
+### p99 レイテンシアラーム（`public-api-p99-latency`）
+
+**症状**: 「Public API Lambda の p99 レイテンシ（AIチャットを除く）が 10 秒を超えた」という SNS/Slack 通知
+
+- このアラームは Lambda の `Duration` ではなく、アプリが EMF で出力するカスタムメトリクス `Rikako/PublicAPI` / `RequestLatency`（ディメンション `Service=public-api`）の p99 を見ている。
+- **AI チャット（`POST /questions/:questionId/chat`）は OpenAI を同期呼び出しするため遅く、このメトリクスから除外済み**（`app/internal/logging/metrics.go`）。チャットだけが遅い場合はこのアラームは鳴らない。
+- 鳴った場合はチャット以外の経路が遅い＝本当の遅延劣化。DB スロークエリ・Neon の CU 不足・コールドスタート増を疑う。
+
+```bash
+# 遅いリクエストをログから特定（latency でソート）
+aws logs filter-log-events \
+  --log-group-name /aws/lambda/rikako-api-development \
+  --start-time $(date -v-15M +%s000) \
+  --filter-pattern '{ $.latency = "*s" }'
+```
+
 ### DB障害（Neon）
 
 **症状**: API が 500 エラー、`connection refused`

--- a/terraform/environments/dev/monitoring.tf
+++ b/terraform/environments/dev/monitoring.tf
@@ -157,16 +157,16 @@ resource "aws_cloudwatch_metric_alarm" "public_api_throttles" {
 
 resource "aws_cloudwatch_metric_alarm" "public_api_p99_latency" {
   alarm_name          = "${local.project}-${local.environment}-public-api-p99-latency"
-  alarm_description   = "Public API Lambda の p99 レイテンシが 10 秒を超えた"
-  namespace           = "AWS/Lambda"
-  metric_name         = "Duration"
+  alarm_description   = "Public API Lambda の p99 レイテンシ（AIチャットを除く）が 10 秒を超えた"
+  namespace           = "Rikako/PublicAPI"
+  metric_name         = "RequestLatency"
   extended_statistic  = "p99"
   period              = 300
   evaluation_periods  = 2
   threshold           = 10000
   comparison_operator = "GreaterThanThreshold"
   treat_missing_data  = "notBreaching"
-  dimensions          = { FunctionName = module.lambda.function_name }
+  dimensions          = { Service = "public-api" }
   alarm_actions       = local.alarm_actions
   ok_actions          = local.alarm_actions
   tags                = local.alarm_tags

--- a/terraform/environments/prod/monitoring.tf
+++ b/terraform/environments/prod/monitoring.tf
@@ -157,16 +157,16 @@ resource "aws_cloudwatch_metric_alarm" "public_api_throttles" {
 
 resource "aws_cloudwatch_metric_alarm" "public_api_p99_latency" {
   alarm_name          = "${local.project}-${local.environment}-public-api-p99-latency"
-  alarm_description   = "Public API Lambda の p99 レイテンシが 10 秒を超えた"
-  namespace           = "AWS/Lambda"
-  metric_name         = "Duration"
+  alarm_description   = "Public API Lambda の p99 レイテンシ（AIチャットを除く）が 10 秒を超えた"
+  namespace           = "Rikako/PublicAPI"
+  metric_name         = "RequestLatency"
   extended_statistic  = "p99"
   period              = 300
   evaluation_periods  = 2
   threshold           = 10000
   comparison_operator = "GreaterThanThreshold"
   treat_missing_data  = "notBreaching"
-  dimensions          = { FunctionName = module.lambda.function_name }
+  dimensions          = { Service = "public-api" }
   alarm_actions       = local.alarm_actions
   ok_actions          = local.alarm_actions
   tags                = local.alarm_tags


### PR DESCRIPTION
## 背景

「Public API Lambda の p99 レイテンシが 10 秒を超えた」アラームが発報。原因はAIチャット（`POST /questions/:questionId/chat`）が **OpenAI APIを同期で叩くため遅く**、同一Lambdaの `Duration` p99 を押し上げていたこと。チャットは仕様上遅いので、アラームから除外する。

## 対応方針

チャット経路を p99 集計から除外し、通常APIの正しいレイテンシSLOを維持する（ユーザー選択）。

## 変更内容

### アプリ (`app/internal/logging/`)
- `metrics.go` を新設。リクエストレイテンシを **CloudWatch EMF** でカスタムメトリクス `Rikako/PublicAPI` / `RequestLatency`（ディメンション `Service=public-api`、単位 Milliseconds）として出力。
  - チャットルート（`/questions/:questionId/chat`）は除外。
  - `AWS_LAMBDA_FUNCTION_NAME` 設定時（＝Lambda実行時）のみ出力。ローカル開発では出さない。
- 既存の `RequestLogger` ミドルウェアから計測済みレイテンシを再利用して emit（二重計測なし）。

### Terraform (`dev` / `prod`)
- `public_api_p99_latency` アラームを `AWS/Lambda` `Duration` → カスタムメトリクス `Rikako/PublicAPI` `RequestLatency` に張り替え。しきい値・p99・評価期間は据え置き。

### ドキュメント
- `docs/runbook.md` にアラーム仕様（チャット除外）と調査手順を追記。

## 補足

- EMFは **stdoutログ経由** でCloudWatchが自動抽出するため、`cloudwatch:PutMetricData` 等の **追加IAM権限は不要**。
- ダッシュボード（`cloudwatch.tf`）のDuration p99ウィジェットは全体把握用にそのまま残置。
- カスタムメトリクスはデプロイ後の非チャットトラフィックで生成される。それまでアラームは `INSUFFICIENT_DATA`（`treat_missing_data=notBreaching`）。

## 確認事項

- [x] `go build ./...` / `go vet ./internal/logging/`
- [x] `terraform validate`（dev / prod）
- [ ] デプロイ後、CloudWatchに `Rikako/PublicAPI/RequestLatency` が出ること
- [ ] チャット連打でアラームが鳴らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)