### PR TITLE
公開APIのp99レイテンシアラーム閾値を10秒→30秒に緩和

### DIFF
--- a/terraform/environments/dev/monitoring.tf
+++ b/terraform/environments/dev/monitoring.tf
@@ -157,13 +157,14 @@ resource "aws_cloudwatch_metric_alarm" "public_api_throttles" {
 
 resource "aws_cloudwatch_metric_alarm" "public_api_p99_latency" {
   alarm_name          = "${local.project}-${local.environment}-public-api-p99-latency"
-  alarm_description   = "Public API Lambda の p99 レイテンシが 10 秒を超えた"
+  # AIチャット(OpenAI同期呼び出し)が遅くp99を押し上げるため、当面30秒に緩和して様子見
+  alarm_description   = "Public API Lambda の p99 レイテンシが 30 秒を超えた"
   namespace           = "AWS/Lambda"
   metric_name         = "Duration"
   extended_statistic  = "p99"
   period              = 300
   evaluation_periods  = 2
-  threshold           = 10000
+  threshold           = 30000
   comparison_operator = "GreaterThanThreshold"
   treat_missing_data  = "notBreaching"
   dimensions          = { FunctionName = module.lambda.function_name }

--- a/terraform/environments/prod/monitoring.tf
+++ b/terraform/environments/prod/monitoring.tf
@@ -157,13 +157,14 @@ resource "aws_cloudwatch_metric_alarm" "public_api_throttles" {
 
 resource "aws_cloudwatch_metric_alarm" "public_api_p99_latency" {
   alarm_name          = "${local.project}-${local.environment}-public-api-p99-latency"
-  alarm_description   = "Public API Lambda の p99 レイテンシが 10 秒を超えた"
+  # AIチャット(OpenAI同期呼び出し)が遅くp99を押し上げるため、当面30秒に緩和して様子見
+  alarm_description   = "Public API Lambda の p99 レイテンシが 30 秒を超えた"
   namespace           = "AWS/Lambda"
   metric_name         = "Duration"
   extended_statistic  = "p99"
   period              = 300
   evaluation_periods  = 2
-  threshold           = 10000
+  threshold           = 30000
   comparison_operator = "GreaterThanThreshold"
   treat_missing_data  = "notBreaching"
   dimensions          = { FunctionName = module.lambda.function_name }


### PR DESCRIPTION
## 背景

「Public API Lambda の p99 レイテンシが 10 秒を超えた」アラームが発報。原因はAIチャット（`POST /questions/:questionId/chat`）が OpenAI を同期で叩くため遅く、同一Lambdaの `Duration` p99 を押し上げていたこと。

カスタムメトリクスでチャットを除外する案もあったが、まずは**閾値を30秒に緩和して様子見**する方針に。

## 変更内容

- `terraform/environments/{dev,prod}/monitoring.tf` の `public_api_p99_latency` アラーム
  - `threshold` 10000 → **30000**（ms）
  - 説明文を「30秒」に更新、緩和理由をコメントで明記

メトリクス・ディメンションは据え置き（`AWS/Lambda` `Duration` p99）。

## 確認事項

- [x] `terraform validate`（dev / prod）
- [ ] apply 後、しばらく発報状況を観察。30秒でも頻発するようなら除外メトリクス案を再検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)