### PR TITLE
fix(ecr): タグ付きイメージを保護しuntaggedのみ期限削除する

### DIFF
--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -4,7 +4,7 @@ module "ecr_api" {
   repository_name      = "rikako-api"
   image_tag_mutability = "MUTABLE"
   scan_on_push         = true
-  max_image_count      = 5
+  untagged_expiry_days = 14
   allowed_account_ids  = local.allowed_account_ids
 
   tags = {
@@ -20,7 +20,7 @@ module "ecr_admin_api" {
   repository_name      = "rikako-admin-api"
   image_tag_mutability = "MUTABLE"
   scan_on_push         = true
-  max_image_count      = 5
+  untagged_expiry_days = 14
   allowed_account_ids  = local.allowed_account_ids
 
   tags = {

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -12,15 +12,20 @@ resource "aws_ecr_repository" "default" {
 resource "aws_ecr_lifecycle_policy" "default" {
   repository = aws_ecr_repository.default.name
 
+  # タグ付きイメージ（:prod / :dev など使用中のもの）は保護し、untagged のみ
+  # 一定期間経過後に削除する。以前は tagStatus=any で件数制限していたため、
+  # dev の連続デプロイで prod が使用中の :prod イメージまで削除され、prod Lambda が
+  # ImageDeleted で起動不能になる事故が発生した。
   policy = jsonencode({
     rules = [
       {
         rulePriority = 1
-        description  = "Keep last ${var.max_image_count} images"
+        description  = "Expire untagged images after ${var.untagged_expiry_days} days (tagged images are kept)"
         selection = {
-          tagStatus   = "any"
-          countType   = "imageCountMoreThan"
-          countNumber = var.max_image_count
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countNumber = var.untagged_expiry_days
+          countUnit   = "days"
         }
         action = {
           type = "expire"

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -15,10 +15,10 @@ variable "scan_on_push" {
   default     = true
 }
 
-variable "max_image_count" {
-  description = "Maximum number of images to keep in the repository"
+variable "untagged_expiry_days" {
+  description = "Number of days after which untagged images are expired. Tagged images (e.g. :prod / :dev) are always kept."
   type        = number
-  default     = 10
+  default     = 14
 }
 
 variable "tags" {


### PR DESCRIPTION
## 背景（インシデント）

prod API が 500 ダウンしていた。原因は **prod Lambda がピン留めしている ECR イメージが削除済み**（`StateReasonCode: ImageDeleted`）で、Lambda が起動できなくなっていたこと。

根本原因は ECR のライフサイクルポリシー：

- dev / prod が **同一の ECR リポジトリ**（`rikako-api` / `rikako-admin-api`）を共有
- ライフサイクルが `tagStatus = "any"` × `imageCountMoreThan = 5`
- → **dev は main push 毎に自動デプロイ**するため、dev の連投で合計5件を超えると、**使用中の `:prod` タグ付きイメージまで古い順に削除**される
- prod は低トラフィックで Lambda が `Inactive` になりやすく、起動時に削除済みダイジェストを pull → `ImageDeleted` → 500

> ※ prod 自体は `deploy-api-prod.yml` / `deploy-admin-api-prod.yml` の再デプロイで復旧済み。本PRは再発防止。

## 変更内容

ライフサイクルを「**タグ付きは全保護・untagged のみ猶予後削除**」に変更：

| 項目 | 変更前 | 変更後 |
|---|---|---|
| `tagStatus` | `any` | `untagged` |
| `countType` | `imageCountMoreThan` | `sinceImagePushed` |
| `countNumber` | `5` | `14` |
| `countUnit` | — | `days` |

- `:prod` / `:dev` はミュータブル単一タグで常に各1枚 → タグ付きは常に保護される。
- 旧イメージはタグが移って untagged 化 → 14日の猶予後に削除（ロールバック余地も確保）。
- モジュール変数 `max_image_count` を `untagged_expiry_days`（デフォルト14）に置換。

## plan 結果（shared）

```
Plan: 2 to add, 0 to change, 2 to destroy.
```

`-/+` の対象は **2つのライフサイクルポリシーのみ**。**ECR リポジトリ本体・イメージには一切触れない**（ポリシー定義差し替えのため replace 表示になるだけ）。

## 確認事項

- [x] `terraform validate` / `terraform fmt -check`
- [x] `terraform plan`（shared）でポリシー2件のみの差分を確認
- [ ] マージ後、shared を手動 apply（`AWS_PROFILE=rikako-shared-sso terraform apply`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)