### PR TITLE
fix(lambda): description を ignore_changes に追加しドリフト抑止

### DIFF
--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -111,7 +111,11 @@ resource "aws_lambda_function" "this" {
   }
 
   lifecycle {
-    ignore_changes = [image_uri]
+    # image_uri はデプロイ(update-function-code)で更新されるため無視。
+    # description は外部のDBクレデンシャルローテーション処理が
+    # コールドスタート強制のために書き換えるため無視（terraform が毎回 null に
+    # 戻そうとして無用な更新=コールドスタートが走るのを防ぐ）。
+    ignore_changes = [image_uri, description]
   }
 
   tags = var.tags


### PR DESCRIPTION
## 背景

prod の `terraform apply` 時、Lambda の `description` が `"cold-start for db rotation <epoch>"` → `null` に戻る差分（drift）が毎回出ていた。これは外部の DB クレデンシャルローテーション処理が、Lambda をコールドスタートさせて SSM を再読込させるために description を書き換えているもの（**この repo の GitHub Actions デプロイは image しか触らず description は設定しない**）。

terraform が毎回 null へ戻そうとするため、apply のたびに無用な Lambda 更新（コールドスタート）と plan ノイズが発生していた。

## 変更内容

`terraform/modules/lambda/main.tf` の `lifecycle.ignore_changes` に `description` を追加（既存の `image_uri` に併記）。

```hcl
ignore_changes = [image_uri, description]
```

## 効果（prod plan で確認済み）

この変更後、prod plan は当初目的のアラーム変更1件のみになる（Lambda 差分が消える）：

```
# aws_cloudwatch_metric_alarm.public_api_p99_latency will be updated in-place
~ threshold = 10000 -> 30000
Plan: 0 to add, 1 to change, 0 to destroy.
```

→ prod apply が Lambda に触れず、コールドスタートなしで通るようになる。

## 補足
- dev/prod 共有モジュールのため dev は merge 後に自動 apply される（description を無視するだけで無害）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)