### PR TITLE
docs を docs.rikako.org (S3+CloudFront) に移行

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,15 +8,12 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  AWS_REGION: ap-northeast-1
+  S3_BUCKET: rikako-docs
 
 permissions:
   contents: read
-  pages: write
   id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -69,18 +66,18 @@ jobs:
       - name: Build docs
         run: mkdocs build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          path: site
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          aws-region: ${{ env.AWS_REGION }}
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Deploy to S3
+        run: aws s3 sync site/ s3://${{ env.S3_BUCKET }}/ --delete
+
+      - name: Invalidate CloudFront
+        run: |
+          DIST_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?contains(Aliases.Items, 'docs.rikako.org')].Id | [0]" \
+            --output text)
+          aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Rikako
 site_description: 問題集アプリ ドキュメント
-site_url: https://takoikatakotako.github.io/rikako/
+site_url: https://docs.rikako.org/
 
 theme:
   name: material

--- a/terraform/environments/prod/dns.tf
+++ b/terraform/environments/prod/dns.tf
@@ -104,3 +104,13 @@ resource "cloudflare_record" "admin" {
   ttl     = 1
   proxied = false
 }
+
+# docs.rikako.org → Docs CloudFront
+resource "cloudflare_record" "docs" {
+  zone_id = data.cloudflare_zone.rikako.id
+  name    = "docs"
+  content = aws_cloudfront_distribution.docs.domain_name
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+}

--- a/terraform/environments/prod/docs_cdn.tf
+++ b/terraform/environments/prod/docs_cdn.tf
@@ -1,0 +1,181 @@
+locals {
+  docs_bucket_name = "${local.project}-docs"
+}
+
+# =============================================================================
+# S3 Bucket for docs (MkDocs build output)
+# =============================================================================
+
+module "docs_s3" {
+  source = "../../modules/s3"
+
+  bucket_name = local.docs_bucket_name
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# =============================================================================
+# CloudFront Distribution for docs.rikako.org
+# =============================================================================
+
+resource "aws_cloudfront_origin_access_control" "docs" {
+  name                              = local.docs_bucket_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ディレクトリインデックスの rewrite（MkDocs の use_directory_urls=true に対応）
+# 例: /runbook/ → /runbook/index.html, /schema → /schema/index.html
+# docs は公開のため Basic Auth は無し。
+resource "aws_cloudfront_function" "docs_dir_index" {
+  name    = "${local.project}-docs-dir-index-${local.environment}"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = <<-EOF
+    function handler(event) {
+      var request = event.request;
+      var uri = request.uri;
+      if (uri.endsWith('/')) {
+        request.uri = uri + 'index.html';
+      } else if (!uri.includes('.')) {
+        request.uri = uri + '/index.html';
+      }
+      return request;
+    }
+  EOF
+}
+
+resource "aws_cloudfront_distribution" "docs" {
+  origin {
+    domain_name              = module.docs_s3.bucket_regional_domain_name
+    origin_id                = "s3-${local.docs_bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.docs.id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Docs for ${local.project}"
+  default_root_object = "index.html"
+  aliases             = ["docs.rikako.org"]
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-${local.docs_bucket_name}"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 86400
+    max_ttl     = 31536000
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.docs_dir_index.arn
+    }
+  }
+
+  # MkDocs Material が生成する 404.html を返す
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.wildcard.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Project     = local.project
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# =============================================================================
+# S3 Bucket Policy - Allow CloudFront access via OAC
+# =============================================================================
+
+resource "aws_s3_bucket_policy" "docs_cdn" {
+  bucket = module.docs_s3.bucket_id
+  policy = data.aws_iam_policy_document.docs_cdn_s3_access.json
+}
+
+data "aws_iam_policy_document" "docs_cdn_s3_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${module.docs_s3.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.docs.arn]
+    }
+  }
+}
+
+# =============================================================================
+# GitHub Actions - S3 docs upload + CloudFront invalidation
+# =============================================================================
+
+resource "aws_iam_role_policy" "github_actions_s3_docs" {
+  name   = "s3-docs-access"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_s3_docs.json
+}
+
+data "aws_iam_policy_document" "github_actions_s3_docs" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.docs_s3.bucket_arn,
+      "${module.docs_s3.bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [aws_cloudfront_distribution.docs.arn]
+  }
+
+  # docs.yml が alias から distribution id を動的解決するため
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudfront:ListDistributions"]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
## 背景

技術ドキュメント（MkDocs）は現状 GitHub Pages（`takoikatakotako.github.io/rikako/`）に公開。これを **`docs.rikako.org`** サブドメインに移し、`api/content/image/admin.rikako.org` と同じ S3+CloudFront(OAC) ファミリーに揃える。

狙い：**LP の `aws s3 sync --delete` と配信系統を完全分離**して事故を防ぐ／docs を独立系統で扱う。

判断：**公開（Basic Auth なし）**。現状の GitHub Pages も公開のため同等。

## 変更内容

### terraform (prod) — `terraform/environments/prod/`
- **`docs_cdn.tf`（新規）**: S3(`rikako-docs`) + CloudFront(OAC) + バケットポリシー + GitHub Actions 用 IAM。
  - 共有ワイルドカード証明書 `*.rikako.org`（`aws_acm_certificate_validation.wildcard`）を再利用 → 追加の証明書発行なし。
  - `aws_cloudfront_function`(cloudfront-js-2.0) で**ディレクトリインデックス rewrite**（`/runbook/` → `/runbook/index.html`）。MkDocs `use_directory_urls=true` 対応。**認証なし**。
  - `default_root_object=index.html`、404→`/404.html`。
- **`dns.tf`**: `docs.rikako.org` の Cloudflare CNAME 追加。

### `mkdocs.yml`
- `site_url` を `https://docs.rikako.org/` に変更。

### `.github/workflows/docs.yml`
- build（postgres→migrate→tbls→mkdocs build）は維持。
- deploy を GitHub Pages → **OIDC + `aws s3 sync site/ s3://rikako-docs/ --delete` + CloudFront invalidation** に変更（`deploy-lp-prod.yml` 踏襲）。
- distribution id は alias から動的解決（ハードコード回避）。

## terraform plan（prod）

```
Plan: 8 to add, 0 to change, 0 to destroy.
```
追加は docs 関連リソースのみ。既存（LP/admin/content/Lambda 等）に差分なし。

## 適用手順（マージ後・prodは手動）

1. `AWS_PROFILE=rikako-production-sso terraform apply`（`terraform/environments/prod`）
2. `docs.yml` を実行（main push or workflow_dispatch）→ `site/` が `rikako-docs` に同期
3. `curl -I https://docs.rikako.org/` → 200 を確認
4. 旧 GitHub Pages はリポジトリ設定で無効化（任意・手動）

## 確認事項
- [x] `terraform validate` / `terraform plan`（prod、docs のみ8追加）
- [x] `docs.yml` YAML 構文
- [ ] apply 後の `docs.rikako.org` 配信確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)