### PR TITLE
fix(docs): 403 も 404 ページにマップする

### DIFF
--- a/terraform/environments/prod/docs_cdn.tf
+++ b/terraform/environments/prod/docs_cdn.tf
@@ -86,9 +86,16 @@ resource "aws_cloudfront_distribution" "docs" {
     }
   }
 
-  # MkDocs Material が生成する 404.html を返す
+  # MkDocs Material が生成する 404.html を返す。
+  # OAC + S3 では存在しないオブジェクトは 403 を返すため、403 も 404 ページにマップする。
   custom_error_response {
     error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 403
     response_code      = 404
     response_page_path = "/404.html"
   }


### PR DESCRIPTION
## 背景

`docs.rikako.org` で存在しないパスにアクセスすると、CloudFront の素の **403 Forbidden** が返っていた。OAC + S3 構成では存在しないオブジェクトに対し S3 が 403 を返すため。

## 変更

`docs_cdn.tf` の CloudFront distribution に `custom_error_response` で **403 → `/404.html`（response 404）** を追加。既存の 404→/404.html と合わせ、MkDocs Material の 404 ページが返るようにする。admin と同じ対応。

## plan（prod）
- `aws_cloudfront_distribution.docs` が in-place 更新（403 の error response 追加）。
- IAM/バケットポリシーの2件は `data.aws_iam_policy_document` の apply時読み取りによる no-op 再適用（内容同一）。

## 適用後の確認
- `curl -I https://docs.rikako.org/nonexistent/` → 404（/404.html）

🤖 Generated with [Claude Code](https://claude.com/claude-code)