### PR TITLE
アプリの利用規約/プライバシーURLを rikako.org に差し替え

### DIFF
--- a/ios/Rikako/Support/Links.swift
+++ b/ios/Rikako/Support/Links.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum Links {
-    static let termsOfService = URL(string: "https://www.google.com")!
-    static let privacyPolicy = URL(string: "https://www.google.com")!
+    static let termsOfService = URL(string: "https://rikako.org/terms")!
+    static let privacyPolicy = URL(string: "https://rikako.org/privacy")!
     static let appStore = "https://apps.apple.com/jp/app/id6744085697"
 }


### PR DESCRIPTION
## 概要

オンボーディングの「利用規約を確認する／プライバシーポリシーを確認する」リンクが `https://www.google.com` のままだった。公開済みの法務ページに差し替える。

## 変更

`ios/Rikako/Support/Links.swift`
- `termsOfService`: `https://www.google.com` → `https://rikako.org/terms`
- `privacyPolicy`: `https://www.google.com` → `https://rikako.org/privacy`

（参照元: `OnboardingView` の利用規約同意ページ）

## 補足
- リンク先（`rikako.org/terms`・`/privacy`）は配信確認済み（200）。
- iOS のソース変更のみ。次回アプリビルドから反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)