### PR TITLE
ci: ECR push を shared の専用ロール経由に変更

### DIFF
--- a/.github/workflows/deploy-admin-api-dev.yml
+++ b/.github/workflows/deploy-admin-api-dev.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (ECR push)
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          role-to-assume: arn:aws:iam::579039992557:role/rikako-ecr-push
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -49,6 +49,12 @@ jobs:
         run: |
           docker build -f app/Dockerfile.admin -t ${{ steps.meta.outputs.tags }} .
           docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Configure AWS credentials (deploy)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Update Lambda function
         env:

--- a/.github/workflows/deploy-admin-api-prod.yml
+++ b/.github/workflows/deploy-admin-api-prod.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (ECR push)
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          role-to-assume: arn:aws:iam::579039992557:role/rikako-ecr-push
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -46,6 +46,12 @@ jobs:
         run: |
           docker build -f app/Dockerfile.admin -t ${{ steps.meta.outputs.tags }} .
           docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Configure AWS credentials (deploy)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Update Lambda function
         env:

--- a/.github/workflows/deploy-api-dev.yml
+++ b/.github/workflows/deploy-api-dev.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (ECR push)
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          role-to-assume: arn:aws:iam::579039992557:role/rikako-ecr-push
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -49,6 +49,12 @@ jobs:
         run: |
           docker build -f app/Dockerfile.lambda -t ${{ steps.meta.outputs.tags }} .
           docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Configure AWS credentials (deploy)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::197865631794:role/rikako-development-github-actions
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Update Lambda function
         env:

--- a/.github/workflows/deploy-api-prod.yml
+++ b/.github/workflows/deploy-api-prod.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (ECR push)
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          role-to-assume: arn:aws:iam::579039992557:role/rikako-ecr-push
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -46,6 +46,12 @@ jobs:
         run: |
           docker build -f app/Dockerfile.lambda -t ${{ steps.meta.outputs.tags }} .
           docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Configure AWS credentials (deploy)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::211125415945:role/rikako-production-github-actions
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Update Lambda function
         env:


### PR DESCRIPTION
## 背景
aws-iac 側で shared ECR(579039992557) を整理し、リポジトリポリシーを **pull-only** に締めた（takoikatakotako/aws-iac#10）。これにより、従来のように **プロジェクトアカウントのロール（rikako-development / rikako-production）からクロスアカウントで push する経路は使えなくなった**。

push は shared に新設した専用ロール **`rikako-ecr-push`**（GitHub OIDC を信頼、push 先を `rikako-api` / `rikako-admin-api` に限定）で行う。詳細: takoikatakotako/aws-iac#11

## 変更内容
各デプロイワークフローの認証を2段に分割：
1. **ECR push 用**: `arn:aws:iam::579039992557:role/rikako-ecr-push` を assume → ECR login → build & push
2. **デプロイ用**: 従来のプロジェクトアカウントロールを assume → Lambda 更新 & smoke test

対象ワークフロー:
- `deploy-api-dev.yml` / `deploy-api-prod.yml`
- `deploy-admin-api-dev.yml` / `deploy-admin-api-prod.yml`

## 確認したいこと / ドラフト理由
- `rikako-ecr-push` ロールの信頼 ref は現状 `repo:takoikatakotako/rikako:*`（全ref）。dev は push@main / prod は workflow_dispatch なので問題なく通るはず。
- プロジェクトアカウントロール側は Lambda 更新・SSM 取得の権限のみ使用（ECR push 権限はもう不要）。
- マージ前に dev を一度流して push→Lambda 更新まで通ることを確認したい。

> 関連: takoikatakotako/aws-iac#11（CI 配線）, #12（旧ECR移行）, #13（ref絞り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)