### PR TITLE
datasync: -env prod を追加（Neon prod の DSN を SSM 解決）

### DIFF
--- a/app/cmd/datasync/main.go
+++ b/app/cmd/datasync/main.go
@@ -15,13 +15,14 @@ import (
 )
 
 const (
-	localDSN    = "postgres://rikako:password@localhost:5432/rikako?sslmode=disable"
-	devSSMParam = "/rikako/dev/database-url"
+	localDSN     = "postgres://rikako:password@localhost:5432/rikako?sslmode=disable"
+	devSSMParam  = "/rikako/dev/database-url"
+	prodSSMParam = "/rikako/prod/database-url"
 )
 
 func main() {
 	dataDir := flag.String("data", "data", "データディレクトリのパス")
-	env := flag.String("env", "local", "接続先環境 (local, dev)")
+	env := flag.String("env", "local", "接続先環境 (local, dev, prod)")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Usage: datasync [flags] <plan|apply>
 
@@ -32,6 +33,7 @@ Subcommands:
 Environments:
   local   ローカルPostgreSQL (localhost:5432)
   dev     Neon dev環境 (SSMからURL取得)
+  prod    Neon prod環境 (SSMからURL取得)
 
 ローカルからdev環境に接続する場合:
   AWS_PROFILE=rikako-development-sso datasync -data ../data -env dev plan
@@ -117,6 +119,8 @@ func resolveDSN(env string) (string, error) {
 		return localDSN, nil
 	case "dev":
 		return fetchDSNFromSSM(devSSMParam)
+	case "prod":
+		return fetchDSNFromSSM(prodSSMParam)
 	default:
 		return "", fmt.Errorf("unknown environment: %s", env)
 	}


### PR DESCRIPTION
## 概要
`datasync` に `-env prod` を追加し、Neon prod の接続URLを SSM `/rikako/prod/database-url` から解決できるようにする。

## 背景
これまで `resolveDSN` の switch は `local` / `dev` のみで、`-env prod` は `unknown environment: prod` で落ちていた。そのため prod へのデータ同期には `DATABASE_URL` の手動上書きが必要だった。リリース前の prod 問題集データ同期にあたり、dev と同様 SSM 経由で恒久的に扱えるようにする。

## 変更点
- `prodSSMParam = "/rikako/prod/database-url"` を追加
- `resolveDSN` に `case "prod"` を追加（dev と同じく `fetchDSNFromSSM`）
- `-env` フラグ説明・Usage 文言に prod を追記

## 確認
- `go build` / `go vet` OK
- `-env prod plan` が SSM ルックアップに到達することを確認（prod SSO ログイン後に実データで実行予定）

## 注意
- prod DB 接続も lib/pq のため、SSM の値は pooler ホスト + `?sslmode=require`（`channel_binding` 不可）である必要あり
- 実行には `AWS_PROFILE=rikako-production-sso aws sso login` が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)