### PR TITLE
fix(datasync): prod の SSM パスを production に修正

### DIFF
--- a/app/cmd/datasync/main.go
+++ b/app/cmd/datasync/main.go
@@ -17,7 +17,7 @@ import (
 const (
 	localDSN     = "postgres://rikako:password@localhost:5432/rikako?sslmode=disable"
 	devSSMParam  = "/rikako/dev/database-url"
-	prodSSMParam = "/rikako/prod/database-url"
+	prodSSMParam = "/rikako/production/database-url"
 )
 
 func main() {


### PR DESCRIPTION
## 概要
`datasync` の prod SSM パスを `/rikako/prod/database-url` → `/rikako/production/database-url` に修正。

## 背景
#224 で `-env prod` を追加した際、パスセグメントを `prod` としていたが、prod 環境の実際の SSM パラメータは `production` セグメント（`/rikako/production/database-url`）。dev は `dev` だが prod は `production` という非対称な命名のため、`-env prod plan` が `ParameterNotFound` で落ちていた。

prod アカウント(211125415945)の SSM 実在パラメータで確認済み:
- `/rikako/production/database-url` ✅
- `/rikako/production/openai-api-key`, `.../slack-*-webhook-url`

## 確認
- `go build` / `go vet` OK
- マージ後、prod 認証下で `-env prod plan` を実行して疎通確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)