### PR TITLE
fix(admin): 画面遷移の不具合修正（ルート切替＋スクロール先頭リセット）

### DIFF
--- a/admin/src/app/layout.tsx
+++ b/admin/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import { Sidebar } from "@/components/layout/sidebar";
+import { ScrollReset } from "@/components/layout/scroll-reset";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -31,8 +32,11 @@ export default function RootLayout({
       >
         <div className="flex h-screen">
           <Sidebar />
-          <main className="flex-1 overflow-auto p-8">{children}</main>
+          <main id="main-scroll" className="flex-1 overflow-auto p-8">
+            {children}
+          </main>
         </div>
+        <ScrollReset />
         <Toaster />
       </body>
     </html>

--- a/admin/src/components/layout/scroll-reset.tsx
+++ b/admin/src/components/layout/scroll-reset.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * 画面遷移時にメインコンテンツ領域を先頭へスクロールし直す。
+ *
+ * スクロール領域は window ではなくレイアウト内側の <main id="main-scroll">
+ * （layout.tsx）であり、Next.js の遷移時スクロールリセットは window を対象に
+ * するため <main> の scrollTop が残ってしまう。pathname の変化を検知して
+ * 明示的に先頭へ戻す。
+ */
+export function ScrollReset() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    document.getElementById("main-scroll")?.scrollTo({ top: 0 });
+  }, [pathname]);
+
+  return null;
+}

--- a/admin/src/hooks/use-route-slug.ts
+++ b/admin/src/hooks/use-route-slug.ts
@@ -1,25 +1,30 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 /**
- * Reads the slug from the browser URL on mount.
+ * Reads the slug from the current pathname.
  * This is needed because Next.js static export embeds slug=[] in the HTML,
  * so direct access to /categories/3 would otherwise show the list page.
+ *
+ * usePathname を購読することで、クライアントサイド遷移（例: /questions/5 →
+ * /questions）でも再評価され、画面が正しく切り替わる。
  */
 export function useRouteSlug(prefix: string) {
+  const pathname = usePathname();
   const [slug, setSlug] = useState<string[] | undefined>(undefined);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const path = window.location.pathname.replace(/\/+$/, "");
+    const path = (pathname ?? "").replace(/\/+$/, "");
     const segments = path.split("/").filter(Boolean);
     // Find prefix index and take everything after it
     const prefixIndex = segments.indexOf(prefix);
     const sub = prefixIndex >= 0 ? segments.slice(prefixIndex + 1) : [];
     setSlug(sub.length > 0 ? sub : undefined);
     setMounted(true);
-  }, [prefix]);
+  }, [prefix, pathname]);
 
   return { slug, mounted };
 }


### PR DESCRIPTION
## 概要
管理画面の画面遷移まわりの不具合を2点修正。dev で動作確認済み。

## 修正1: クライアント遷移でルートが切り替わらない
`useRouteSlug` が `window.location` をマウント時に一度だけ読む実装だったため、同一 `[[...slug]]` ルート内のクライアント遷移（例: `/questions/5` → `/questions`）で slug が更新されず、画面が切り替わらなかった。
→ `usePathname` を購読し、パス変化で slug を再評価。全画面共通 hook のため categories/workbooks/users 等すべての遷移に効く。

- `admin/src/hooks/use-route-slug.ts`

## 修正2: 遷移時にスクロール位置が先頭に戻らない（#226）
スクロール領域が window ではなくレイアウト内側の `<main className="overflow-auto">` のため、Next.js の遷移時スクロールリセット（window 対象）が効かず、前画面のスクロール位置が残っていた。
→ `usePathname` を購読する `ScrollReset` を追加し、パス変化時に `<main id="main-scroll">` を `scrollTo({ top: 0 })`。

- `admin/src/components/layout/scroll-reset.tsx`（新規）
- `admin/src/app/layout.tsx`

この2点が揃うことで「詳細→一覧／別問題に切り替わり、かつ先頭から表示」が成立する。

## 確認
- `npm run build`（static export）成功
- dev（admin.dev.rikako.org）にデプロイし、詳細→一覧／詳細→詳細の遷移で切替＋先頭表示を確認
- lint: 追加・変更分に新規指摘なし（既存の warning は本PR対象外）

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)